### PR TITLE
feat: Add exists service method and request/response messages.

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -47,6 +47,7 @@ message _ExistsRequest {
 }
 
 message _ExistsResponse {
+  // Order and count of results matches the request list.
   repeated bool results = 1;
   string message = 2;
 }

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -20,6 +20,7 @@ service Scs {
   rpc Get (_GetRequest) returns (_GetResponse) {}
   rpc Set (_SetRequest) returns (_SetResponse) {}
   rpc Delete (_DeleteRequest) returns (_DeleteResponse) {}
+  rpc Exists (_ExistsRequest) returns (_ExistsREsponse) {}
   rpc DictionaryGet (_DictionaryGetRequest) returns (_DictionaryGetResponse) {}
   rpc DictionaryGetAll (_DictionaryGetAllRequest) returns (_DictionaryGetAllResponse) {}
   rpc DictionarySet (_DictionarySetRequest) returns (_DictionarySetResponse) {}
@@ -40,6 +41,15 @@ message _DeleteRequest {
 }
 
 message _DeleteResponse {}
+
+message _ExistsRequest {
+  repeated bytes keys = 1;
+}
+
+message _ExistsResponse {
+  repeated bool results;
+  string message = 2;
+}
 
 message _SetRequest {
   bytes cache_key = 1;

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -47,7 +47,7 @@ message _ExistsRequest {
 }
 
 message _ExistsResponse {
-  repeated bool results;
+  repeated bool results = 1;
   string message = 2;
 }
 

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -20,7 +20,7 @@ service Scs {
   rpc Get (_GetRequest) returns (_GetResponse) {}
   rpc Set (_SetRequest) returns (_SetResponse) {}
   rpc Delete (_DeleteRequest) returns (_DeleteResponse) {}
-  rpc Exists (_ExistsRequest) returns (_ExistsREsponse) {}
+  rpc Exists (_ExistsRequest) returns (_ExistsResponse) {}
   rpc DictionaryGet (_DictionaryGetRequest) returns (_DictionaryGetResponse) {}
   rpc DictionaryGetAll (_DictionaryGetAllRequest) returns (_DictionaryGetAllResponse) {}
   rpc DictionarySet (_DictionarySetRequest) returns (_DictionarySetResponse) {}


### PR DESCRIPTION
`Exists` takes a list of keys as input and returns a list of `bool`s. `results[i]` is `True` if `keys[i]` exists, else `False`.

We decided on returning a *list* as opposed to the count of items. By doing this we can support rich iteration use cases on the client side. For example:

```python
response = client.exists("my-cache", *keys)
if not response.all():
   log.info(f"Expected {len(keys)} to exist but got {response.num_exists()}")
   for missing_key in response.missing_keys():
       # Do things
```