### PR TITLE
feat: Add protos for GenerateApiV1Token

### DIFF
--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -7,7 +7,7 @@ package auth;
 
 service Auth {
   rpc Login (_LoginRequest) returns (stream _LoginResponse) {}
-  rpc GenerateApiV1Token(_GenerateApiV1TokenRequest) returns (_GenerateApiV1TokenResponse) {}
+  rpc GenerateApiVToken(_GenerateApiTokenRequest) returns (_GenerateApiTokenResponse) {}
 }
 
 message _LoginRequest {
@@ -51,11 +51,11 @@ message _LoginResponse {
   }
 }
 
-message _GenerateApiV1TokenRequest {
+message _GenerateApiTokenRequest {
   uint32 expiration_minutes = 1;
 }
 
-message _GenerateApiV1TokenResponse {
+message _GenerateApiTokenResponse {
   _Token token = 1;
 }
 

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -7,6 +7,7 @@ package auth;
 
 service Auth {
   rpc Login (_LoginRequest) returns (stream _LoginResponse) {}
+  rpc GenerateApiV1Token(_GenerateApiV1TokenRequest) returns (_GenerateApiV1TokenResponse) {}
 }
 
 message _LoginRequest {
@@ -48,4 +49,18 @@ message _LoginResponse {
   message Message {
     string text = 1;
   }
+}
+
+message _GenerateApiV1TokenRequest {
+  uint32 expiration_minutes = 1;
+}
+
+message _GenerateApiV1TokenResponse {
+  _Token token = 1;
+}
+
+message _Token {
+  string token = 1;
+  // Epoch time in seconds when the token expires
+  uint64 expires_at = 2;
 }


### PR DESCRIPTION
Add protos for allowing users to programmatically generating API tokens with a specified expiration length, e.g. `momento api-token generate --expiration 30` would generate a token expiring in 30 minutes.

I'm not wedded to the name `GenerateApiV1Token` - could be `CreateApiV1Token`, I don't care super strongly either way?