### PR TITLE
feat: Add proto for SetMultipleIfNotExists

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -21,6 +21,8 @@ service Scs {
   rpc Set (_SetRequest) returns (_SetResponse) {}
   rpc Delete (_DeleteRequest) returns (_DeleteResponse) {}
 
+  rpc SetMultipleIfNotExists (_SetMultipleIfNotExistsRequest) returns (_SetMultipleIfNotExistsResponse) {}
+
   rpc DictionaryGet (_DictionaryGetRequest) returns (_DictionaryGetResponse) {}
   rpc DictionaryFetch (_DictionaryFetchRequest) returns (_DictionaryFetchResponse) {}
   rpc DictionarySet (_DictionarySetRequest) returns (_DictionarySetResponse) {}
@@ -68,6 +70,29 @@ message _SetRequest {
 message _SetResponse {
   ECacheResult result = 1;
   string message = 2;
+}
+
+message _KeyValuePair {
+  bytes field = 1;
+  bytes value = 2;
+}
+
+message _SetMultipleIfNotExistsRequest {
+  repeated _KeyValuePair items = 1;
+  uint64 ttl_milliseconds = 2;
+  bool refresh_ttl = 3;
+}
+
+message _SetMultipleIfNotExistsResponse {
+  message _SetMultipleIfNotExistsResponsePart {
+    oneof result {
+      Ok ok = 1;
+      NotStored not_stored = 2;
+    }
+    message Ok { }
+    message NotStored { }
+  }
+  repeated _SetMultipleIfNotExistsResponsePart items = 1;
 }
 
 message _DictionaryGetRequest {


### PR DESCRIPTION
`SetMultipleIfNotExists` allows for setting multiple key-value pairs. Each will be set only if the key does not exist (was not previously set).

- Redis' behavior for [`MSETNX`](https://redis.io/commands/msetnx/) is to only set any keys if no keys exists. If no keys exist then all keys will be set, but if any key exists then no keys will be set. It's an atomic set of all keys.
- With a multi-node set up, we can't easily support atomic set for multiple keys.
- Instead, we will set any keys that don't exist.
- Since we're doing this behavior on each key, we'll return a result for each key - whether it was stored or not.
