### PR TITLE
feat: Add an RPC to support flushing caches

### DIFF
--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -11,6 +11,7 @@ service ScsControl {
   rpc CreateCache (_CreateCacheRequest) returns (_CreateCacheResponse) {}
   rpc DeleteCache (_DeleteCacheRequest) returns (_DeleteCacheResponse) {}
   rpc ListCaches (_ListCachesRequest) returns (_ListCachesResponse) {}
+  rpc FlushCache (_FlushCacheRequest) returns (_FlushCacheResponse) {}
   rpc CreateSigningKey (_CreateSigningKeyRequest) returns (_CreateSigningKeyResponse) {}
   rpc RevokeSigningKey (_RevokeSigningKeyRequest) returns (_RevokeSigningKeyResponse) {}
   rpc ListSigningKeys (_ListSigningKeysRequest) returns (_ListSigningKeysResponse) {}
@@ -67,10 +68,18 @@ message _SigningKey {
 }
 
 message _ListSigningKeysRequest {
-  string next_token = 1; 
+  string next_token = 1;
 }
 
 message _ListSigningKeysResponse {
   repeated _SigningKey signing_key = 1;
   string next_token = 2;
+}
+
+message _FlushCacheRequest {
+  string cache_name = 1;
+}
+
+message _FlushCacheResponse {
+
 }


### PR DESCRIPTION
The RPC will allow callers to flush all the data from a given cache. Once this operation is invoked on a cache all the data prior to invoking the operation will not be available to the callers.