### PR TITLE
feat: add "Ping" rpc, for use in ensuring connections are active

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -17,6 +17,8 @@ enum ECacheResult {
 }
 
 service Scs {
+  rpc Ping (_PingRequest) returns (_PingResponse) {}
+
   rpc Get (_GetRequest) returns (_GetResponse) {}
   rpc Set (_SetRequest) returns (_SetResponse) {}
   rpc Delete (_DeleteRequest) returns (_DeleteResponse) {}
@@ -42,6 +44,9 @@ service Scs {
   rpc ListConcatenateFront(_ListConcatenateFrontRequest) returns (_ListConcatenateFrontResponse) {}
   rpc ListConcatenateBack(_ListConcatenateBackRequest) returns (_ListConcatenateBackResponse) {}
 }
+
+message _PingRequest {}
+message _PingResponse {}
 
 message _GetRequest {
   bytes cache_key = 1;


### PR DESCRIPTION
This commit adds a basic Ping RPC.  Empty request payload, empty
response payload.  This can be used to ensure that the client/server
connection is healthy, or, for clients that don't provide a mechanism
to eagerly establish the connection, this gives us a way to do it
without impacting cache metrics for the client.
