### PR TITLE
feat: move ping RPC to separate service

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -16,9 +16,14 @@ enum ECacheResult {
   reserved 4 to 6;
 }
 
-service Scs {
+service PingService {
   rpc Ping (_PingRequest) returns (_PingResponse) {}
+}
 
+message _PingRequest {}
+message _PingResponse {}
+
+service Scs {
   rpc Get (_GetRequest) returns (_GetResponse) {}
   rpc Set (_SetRequest) returns (_SetResponse) {}
   rpc Delete (_DeleteRequest) returns (_DeleteResponse) {}
@@ -44,9 +49,6 @@ service Scs {
   rpc ListConcatenateFront(_ListConcatenateFrontRequest) returns (_ListConcatenateFrontResponse) {}
   rpc ListConcatenateBack(_ListConcatenateBackRequest) returns (_ListConcatenateBackResponse) {}
 }
-
-message _PingRequest {}
-message _PingResponse {}
 
 message _GetRequest {
   bytes cache_key = 1;


### PR DESCRIPTION
The main cache service requires a "cache" header with a valid
cache name on every request.  This doesn't work well for the
Ping RPC because we won't necessarily know a cache name (and we
really don't need to know one) at the time we issue the request.

Rather than hacking a bunch of special case logic into the
already-fairly-complex auth interceptor for the cache service,
this moves the ping RPC to a separate service where we can
run without those requirements.
