### PR TITLE
feat: Add protos for Integer type

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -42,6 +42,10 @@ service Scs {
   rpc ListLength(_ListLengthRequest) returns (_ListLengthResponse) {}
   rpc ListConcatenateFront(_ListConcatenateFrontRequest) returns (_ListConcatenateFrontResponse) {}
   rpc ListConcatenateBack(_ListConcatenateBackRequest) returns (_ListConcatenateBackResponse) {}
+
+  rpc IntegerGet(_IntegerGetRequest) returns (_IntegerGetRequest) {}
+  rpc IntegerIncrement(_IntegerIncrementRequest) returns (_IntegerIncrementResponse) {}
+  rpc IntegerSet(_IntegerSetRequest) returns (_IntegerSetResponse) {}
 }
 
 message _GetRequest {
@@ -391,3 +395,40 @@ message _ListLengthResponse {
     _Missing missing = 2;
   }
 }
+
+message _IntegerGetRequest {
+  bytes integer_name = 1;
+}
+
+message _IntegerGetResponse {
+  message _Found {
+    int64 value = 1;
+  }
+
+  message _Missing {}
+
+  oneof integer {
+    _Found found = 1;
+    _Missing missing = 2;
+  }
+}
+
+message _IntegerIncrementRequest {
+  bytes integer_name = 1;
+  int64 increment_by = 2;
+  uint64 ttl_milliseconds = 3;
+  bool refresh_ttl = 4;
+}
+
+message _IntegerIncrementResponse {
+  int64 value = 1;
+}
+
+message _IntegerSetRequest {
+  bytes integer_name = 1;
+  int64 value = 2;
+  uint64 ttl_milliseconds = 3;
+  bool refresh_ttl = 4;
+}
+
+message _IntegerSetResponse {}


### PR DESCRIPTION
Add protos for APIs for get, set, and increment on integer type.

This is called `Integer` rather than `Counter` because it can be assigned in addition to being incremented. It is `Integer` so that should we ever want to add support for floats, we can add `Number`.

Although this is not part of the protos, a few implementation details:
- If increment is called on an integer that does not yet exist, it will be initialized as 0 first.
- ~~If increment is called without a provided value to increment by, it will default to incrementing by 1.~~ Default will be 0 because that is what proto3 has for missing value for int64 - that is the service will increment by whatever value it receives. If we want we could have SDKs provide 1 as a default.
- The value to increment by can be negative (that is, `Increment` will do all the things the Redis `INCR`, `DECR`, `INCRBY`, and `DECRBY` commands do, in one API.)
