### PR TITLE
feat: Add Increment API

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -139,6 +139,16 @@ message _DictionarySetRequest {
 
 message _DictionarySetResponse {}
 
+message _IncrementRequest {
+  bytes cache_key = 1;
+  int64 increment_by = 2;
+  uint64 ttl_milliseconds = 3;
+}
+
+message _IncrementResponse {
+  int64 value = 1;
+}
+
 message _DictionaryIncrementRequest {
   bytes dictionary_name = 1;
   bytes field = 2;

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -141,11 +141,14 @@ message _DictionarySetResponse {}
 
 message _IncrementRequest {
   bytes cache_key = 1;
+  // Amount to add to the stored value.
+  // If this key doesn't currently exist, it's created with this value (encoded as a base 10 string)
   int64 increment_by = 2;
   uint64 ttl_milliseconds = 3;
 }
 
 message _IncrementResponse {
+  // The value stored after the increment operation.
   int64 value = 1;
 }
 

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -21,6 +21,7 @@ service Scs {
   rpc Set (_SetRequest) returns (_SetResponse) {}
   rpc SetIfNotExists (_SetIfNotExistsRequest) returns (_SetIfNotExistsResponse) {}
   rpc Delete (_DeleteRequest) returns (_DeleteResponse) {}
+  rpc Increment (_IncrementRequest) returns (_IncrementResponse) {}
 
   rpc DictionaryGet (_DictionaryGetRequest) returns (_DictionaryGetResponse) {}
   rpc DictionaryFetch (_DictionaryFetchRequest) returns (_DictionaryFetchResponse) {}
@@ -85,6 +86,20 @@ message _SetIfNotExistsResponse {
   message _Stored { }
   message _NotStored { }
 }
+
+message _IncrementRequest {
+  bytes cache_key = 1;
+  // Amount to add to the stored value.
+  // If this key doesn't currently exist, it's created with this value (encoded as a base 10 string)
+  int64 increment_by = 2;
+  uint64 ttl_milliseconds = 3;
+}
+
+message _IncrementResponse {
+  // The value stored after the increment operation.
+  int64 value = 1;
+}
+
 message _DictionaryGetRequest {
   bytes dictionary_name = 1;
   repeated bytes fields = 2;
@@ -138,19 +153,6 @@ message _DictionarySetRequest {
 }
 
 message _DictionarySetResponse {}
-
-message _IncrementRequest {
-  bytes cache_key = 1;
-  // Amount to add to the stored value.
-  // If this key doesn't currently exist, it's created with this value (encoded as a base 10 string)
-  int64 increment_by = 2;
-  uint64 ttl_milliseconds = 3;
-}
-
-message _IncrementResponse {
-  // The value stored after the increment operation.
-  int64 value = 1;
-}
 
 message _DictionaryIncrementRequest {
   bytes dictionary_name = 1;


### PR DESCRIPTION
Add proto definitions for rpc, request, and response for `Increment`.

`Increment` takes a key, an integer by which to increment by (can be negative to decrement), and a ttl. If the key does not already exist, it initializes it at 0.

The `Increment` operation maybe may fail if the stored value (which is stored as a string) does not parse to a number. Currently this error will surface as an `Unavailable` error; in my opinion in order for this API to be usable we will want to make sure we surface the full error.
