### PR TITLE
feat: Add RPCs to support sorted sets

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -53,7 +53,7 @@ service Scs {
   // element and its associated score.
   // If an element exists, then its associate score gets overridden with the one
   // provided in this operation.
-  rpc SortedSetAdd(_SortedSetAddRequest) returns (_SortedSetAddResponse) {}
+  rpc SortedSetPut(_SortedSetPutRequest) returns (_SortedSetputResponse) {}
   // Fetches all the elements in the sorted set.
   rpc SortedSetFetch(_SortedSetFetchRequest) returns (_SortedSetFetchResponse) {}
   // Gets the specified element and its associated score if it exists in the
@@ -440,14 +440,14 @@ message _SortedSetElement {
   double score = 2;
 }
 
-message _SortedSetAddRequest {
+message _SortedSetPutRequest {
   bytes set_name = 1;
   repeated _SortedSetElement elements = 2;
   uint64 ttl_milliseconds = 3;
   bool refresh_ttl = 4;
 }
 
-message _SortedSetAddResponse {}
+message _SortedSetPutResponse {}
 
 message _SortedSetFetchRequest {
   enum Order {

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -450,25 +450,24 @@ message _SortedSetAddRequest {
 message _SortedSetAddResponse {}
 
 message _SortedSetFetchRequest {
-  enum SortOrder {
+  enum Order {
     UNKNOWN = 0;
     ASCENDING = 1;
     DESCENDING = 2;
   }
 
-  message Filters {
-    message All {
+  message _All {}
 
-    }
-    message Some {
-      int64 startIndex = 1;
-      int64 endIndex = 2;
-    }
-
+  message _Limit {
+    uint32 limit = 1;
   }
 
   bytes set_name = 1;
-  SortOrder order = 2;
+  Order order = 2;
+  oneof num_results {
+    _All all = 3;
+    _Limit limit = 4;
+  }
 }
 
 message _SortedSetFetchResponse {

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -53,7 +53,7 @@ service Scs {
   // element and its associated score.
   // If an element exists, then its associate score gets overridden with the one
   // provided in this operation.
-  rpc SortedSetPut(_SortedSetPutRequest) returns (_SortedSetputResponse) {}
+  rpc SortedSetPut(_SortedSetPutRequest) returns (_SortedSetPutResponse) {}
   // Fetches all the elements in the sorted set.
   rpc SortedSetFetch(_SortedSetFetchRequest) returns (_SortedSetFetchResponse) {}
   // Gets the specified element and its associated score if it exists in the

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -43,6 +43,32 @@ service Scs {
   rpc ListLength(_ListLengthRequest) returns (_ListLengthResponse) {}
   rpc ListConcatenateFront(_ListConcatenateFrontRequest) returns (_ListConcatenateFrontResponse) {}
   rpc ListConcatenateBack(_ListConcatenateBackRequest) returns (_ListConcatenateBackResponse) {}
+
+  // Sorted Set Operations
+  // A sorted set is a collection of elements ordered by their score.
+  // The elements with same score are ordered lexicographically.
+
+  // Add or Updates new element with its score to the Sorted Set.
+  // If sorted set doesn't exist, a new one is created with the specified
+  // element and its associated score.
+  // If an element exists, then its associate score gets overridden with the one
+  // provided in this operation.
+  rpc SortedSetAdd(_SortedSetAddRequest) returns (_SortedSetAddResponse) {}
+  // Fetches all the elements in the sorted set.
+  rpc SortedSetFetch(_SortedSetFetchRequest) returns (_SortedSetFetchResponse) {}
+  // Gets the specified element and its associated score if it exists in the
+  // sorted set.
+  rpc SortedSetGet(_SortedSetGetRequest) returns (_SortedSetGetResponse) {}
+  // Removes the specified element from the Sorted Set.
+  rpc SortedSetRemove(_SortedSetRemoveRequest) returns (_SortedSetRemoveResponse) {}
+  // Changes the score associated with the element by specified amount.
+  // If the provided amount is negative, then the score associated with the
+  // element is decremented.
+  // If the element that needs to be incremented isn't present in the sorted
+  // set, it is added with specified number as the score.
+  // If the set itself doesn't exist then a new one with specified element and
+  // score is created.
+  rpc SortedSetIncrement(_SortedSetIncrementRequest) returns (_SortedSetIncrementResponse) {}
 }
 
 message _GetRequest {
@@ -406,3 +432,77 @@ message _ListLengthResponse {
     _Missing missing = 2;
   }
 }
+
+message _SortedSetElement {
+  bytes name = 1;
+  double score = 2;
+}
+
+message _SortedSetAddRequest {
+  bytes set_name = 1;
+  repeated _SortedSetElement elements = 2;
+  uint64 ttl_milliseconds = 3;
+  bool refresh_ttl = 4;
+}
+
+message _SortedSetAddResponse {}
+
+message _SortedSetFetchRequest {
+  enum Order {
+    UNKNOWN = 0;
+    ASCENDING = 1;
+    DESCENDING = 2;
+  }
+  bytes set_name = 1;
+  Order order = 2;
+}
+
+message _SortedSetFetchResponse {
+  message _Found {
+    repeated _SortedSetElement elements = 1;
+  }
+
+  message _Missing {
+  }
+
+  oneof sorted_set {
+    _Found found = 1;
+    _Missing missing = 2;
+  }
+}
+
+message _SortedSetGetRequest {
+  bytes set_name = 1;
+  bytes element_name = 2;
+}
+
+message _SortedSetGetResponse {
+  message _Found {
+    _SortedSetElement element = 1;
+  }
+
+  message _Missing {
+  }
+
+  oneof sorted_set {
+    _Found found = 1;
+    _Missing missing = 2;
+  }
+}
+
+message _SortedSetRemoveRequest {
+  bytes set_name = 1;
+  bytes element_name = 2;
+}
+
+message _SortedSetRemoveResponse {}
+
+message _SortedSetIncrementRequest {
+  bytes set_name = 1;
+  bytes element_name = 2;
+  double amount = 3;
+  uint64 ttl_milliseconds = 4;
+  bool refresh_ttl = 5;
+}
+
+message _SortedSetIncrementResponse {}

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -58,8 +58,8 @@ service Scs {
   rpc SortedSetFetch(_SortedSetFetchRequest) returns (_SortedSetFetchResponse) {}
   // Gets the specified element and its associated score if it exists in the
   // sorted set.
-  rpc SortedSetGet(_SortedSetGetRequest) returns (_SortedSetGetResponse) {}
-  // Removes the specified element from the Sorted Set.
+  rpc SortedSetScore(_SortedSetScoreRequest) returns (_SortedSetScoreResponse) {}
+  // Removes specified elements and their associated scores
   rpc SortedSetRemove(_SortedSetRemoveRequest) returns (_SortedSetRemoveResponse) {}
   // Changes the score associated with the element by specified amount.
   // If the provided amount is negative, then the score associated with the
@@ -69,6 +69,8 @@ service Scs {
   // If the set itself doesn't exist then a new one with specified element and
   // score is created.
   rpc SortedSetIncrement(_SortedSetIncrementRequest) returns (_SortedSetIncrementResponse) {}
+  // Gives the rank of an element.
+  rpc SortedSetRank(_SortedSetRankRequest) returns (_SortedSetRankResponse) {}
 }
 
 message _GetRequest {
@@ -448,13 +450,25 @@ message _SortedSetAddRequest {
 message _SortedSetAddResponse {}
 
 message _SortedSetFetchRequest {
-  enum Order {
+  enum SortOrder {
     UNKNOWN = 0;
     ASCENDING = 1;
     DESCENDING = 2;
   }
+
+  message Filters {
+    message All {
+
+    }
+    message Some {
+      int64 startIndex = 1;
+      int64 endIndex = 2;
+    }
+
+  }
+
   bytes set_name = 1;
-  Order order = 2;
+  SortOrder order = 2;
 }
 
 message _SortedSetFetchResponse {
@@ -471,28 +485,40 @@ message _SortedSetFetchResponse {
   }
 }
 
-message _SortedSetGetRequest {
+message _SortedSetScoreRequest {
   bytes set_name = 1;
-  bytes element_name = 2;
+  repeated bytes element_name = 2;
 }
 
-message _SortedSetGetResponse {
-  message _Found {
-    _SortedSetElement element = 1;
+message _SortedSetScoreResponse {
+  message _SortedSetScoreResponsePart {
+    ECacheResult result = 1;
+    double score = 2;
   }
 
-  message _Missing {
+  message _SortedSetFound {
+    repeated _SortedSetScoreResponsePart elements = 1;
+  }
+
+  message _SortedSetMissing {
   }
 
   oneof sorted_set {
-    _Found found = 1;
-    _Missing missing = 2;
+    _SortedSetFound found = 1;
+    _SortedSetMissing missing = 2;
   }
 }
 
 message _SortedSetRemoveRequest {
   bytes set_name = 1;
-  bytes element_name = 2;
+  message _All {}
+  message _Some {
+    repeated bytes element_name = 1;
+  }
+  oneof remove_elemnts {
+    _All all = 2;
+    _Some some = 3;
+  }
 }
 
 message _SortedSetRemoveResponse {}
@@ -506,3 +532,22 @@ message _SortedSetIncrementRequest {
 }
 
 message _SortedSetIncrementResponse {}
+
+message _SortedSetRankRequest {
+  bytes set_name = 1;
+  bytes element_name = 2;
+}
+
+message _SortedSetRankResponse {
+  message _RankResponsePart {
+    ECacheResult result = 1;
+    uint64 rank = 2;
+  }
+
+  message _SortedSetMissing {}
+
+  oneof rank {
+    _RankResponsePart element_rank = 1;
+    _SortedSetMissing missing = 2;
+  }
+}

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -58,7 +58,7 @@ service Scs {
   rpc SortedSetFetch(_SortedSetFetchRequest) returns (_SortedSetFetchResponse) {}
   // Gets the specified element and its associated score if it exists in the
   // sorted set.
-  rpc SortedSetScore(_SortedSetScoreRequest) returns (_SortedSetScoreResponse) {}
+  rpc SortedSetGetScore(_SortedSetGetScoreRequest) returns (_SortedSetGetScoreResponse) {}
   // Removes specified elements and their associated scores
   rpc SortedSetRemove(_SortedSetRemoveRequest) returns (_SortedSetRemoveResponse) {}
   // Changes the score associated with the element by specified amount.
@@ -70,7 +70,7 @@ service Scs {
   // score is created.
   rpc SortedSetIncrement(_SortedSetIncrementRequest) returns (_SortedSetIncrementResponse) {}
   // Gives the rank of an element.
-  rpc SortedSetRank(_SortedSetRankRequest) returns (_SortedSetRankResponse) {}
+  rpc SortedSetGetRank(_SortedSetGetRankRequest) returns (_SortedSetGetRankResponse) {}
 }
 
 message _GetRequest {
@@ -484,19 +484,19 @@ message _SortedSetFetchResponse {
   }
 }
 
-message _SortedSetScoreRequest {
+message _SortedSetGetScoreRequest {
   bytes set_name = 1;
   repeated bytes element_name = 2;
 }
 
-message _SortedSetScoreResponse {
-  message _SortedSetScoreResponsePart {
+message _SortedSetGetScoreResponse {
+  message _SortedSetGetScoreResponsePart {
     ECacheResult result = 1;
     double score = 2;
   }
 
   message _SortedSetFound {
-    repeated _SortedSetScoreResponsePart elements = 1;
+    repeated _SortedSetGetScoreResponsePart elements = 1;
   }
 
   message _SortedSetMissing {
@@ -532,12 +532,12 @@ message _SortedSetIncrementRequest {
 
 message _SortedSetIncrementResponse {}
 
-message _SortedSetRankRequest {
+message _SortedSetGetRankRequest {
   bytes set_name = 1;
   bytes element_name = 2;
 }
 
-message _SortedSetRankResponse {
+message _SortedSetGetRankResponse {
   message _RankResponsePart {
     ECacheResult result = 1;
     uint64 rank = 2;


### PR DESCRIPTION
A sorted set is a collection of elementes ordered by their associated scores.

This PR introduces basic operations to start of supporting sorted sets.

Here is the notion doc for these protos https://www.notion.so/momentohq/Sorted-Sets-5898891409fe4dd88c053bf26ab1d62f