### PR TITLE
fix: generate rust files under `$OUT_DIR` instead of `src`

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,14 +1,26 @@
 use std::io::Result;
+use std::path::PathBuf;
 
 fn main() -> Result<()> {
+    let out_dir = std::env::var_os("OUT_DIR").expect("OUT_DIR env var was not set");
+
     tonic_build::configure()
         .build_client(true)
         .build_server(true)
-        .out_dir("src/")
         .compile(
-            &["proto/controlclient.proto", "proto/cacheclient.proto", "proto/auth.proto"],
+            &[
+                "proto/controlclient.proto",
+                "proto/cacheclient.proto",
+                "proto/auth.proto",
+            ],
             &["proto"],
         )
         .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));
+
+    // #[path = ".."] attributes don't allow us to specify paths relative to
+    // the OUT_DIR environment variable. To work around this we generate a mod.rs
+    // file in OUT_DIR and use include! within lib.rs.
+    std::fs::copy("src/lib.tmpl.rs", PathBuf::from(out_dir).join("mod.rs"))?;
+
     Ok(())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,1 @@
-pub mod cache_client;
-pub mod control_client;
-pub mod auth;
+include!(concat!(env!("OUT_DIR"), "/mod.rs"));

--- a/rust/src/lib.tmpl.rs
+++ b/rust/src/lib.tmpl.rs
@@ -1,0 +1,6 @@
+// This file is copied to $OUT_DIR so that it can be used for rust modules
+// generated there. All the real lib.rs file does is include! this one.
+
+pub mod auth;
+pub mod cache_client;
+pub mod control_client;


### PR DESCRIPTION
Right now, the rust crate generates files in the `src` folder. Build scripts are not supposed to do that because it corrupts the cargo registry. In most cases this doesn't cause any visible problems since the registry is writable. However, places which would like to avoid having random crates mess with the registry, such as docs.rs, make the registry read only. This is what is causing the build failures on docs.rs ([see here](https://docs.rs/crate/momento-protos/0.40.0/builds/720561).

The correct fix for this is to use the directory cargo provides for these artifacts. The `$OUT_DIR` environment variable points to a directory in the target directory that is meant to be used for build script outputs. By generating files there we can ensure that the build will work correctly in all rust environments.

The one (small) hack I needed to put in was to generate a mod.rs file in `$OUT_DIR` that has the `mod` statements and use `include!` to bring it into the main file. Normally, I'd use the `#[path]` attribute macro but while this works
```rs
include!(concat!(env!(OUT_DIR), "/x.rs");
```
this does not
```rs
#[path = concat!(env!(OUT_DIR), "/x.rs")]
pub mod x
```
so unfortunately copying a file around was the only way I could find to make this work.