### PR TITLE
feat: add pubsub definitions to rust package

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -6,9 +6,10 @@ fn main() -> Result<()> {
         .build_server(true)
         .compile(
             &[
-                "proto/controlclient.proto",
-                "proto/cacheclient.proto",
                 "proto/auth.proto",
+                "proto/cacheclient.proto",
+                "proto/cachepubsub.proto",
+                "proto/controlclient.proto",
             ],
             &["proto"],
         )

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,6 +4,10 @@ pub mod auth {
 
 pub mod cache_client {
   tonic::include_proto!("cache_client");
+
+  pub mod pubsub {
+    tonic::include_proto!("cache_client.pubsub");
+  }
 }
 
 pub mod control_client {


### PR DESCRIPTION
Enable generated code for the pubsub messages in rust.
