### PR TITLE
fix: remove unknown as valid order option, fix typos

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -514,7 +514,7 @@ message _SortedSetRemoveRequest {
   message _Some {
     repeated bytes element_name = 1;
   }
-  oneof remove_elemnts {
+  oneof remove_elements {
     _All all = 2;
     _Some some = 3;
   }

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -451,9 +451,8 @@ message _SortedSetPutResponse {}
 
 message _SortedSetFetchRequest {
   enum Order {
-    UNKNOWN = 0;
-    ASCENDING = 1;
-    DESCENDING = 2;
+    ASCENDING = 0;
+    DESCENDING = 1;
   }
 
   message _All {}


### PR DESCRIPTION
renames `elemnt` to `element` for sorted set remove elements request

removes `unknown` as a valid option for when fetching a sorted set

https://gomomento.slack.com/archives/C03HUJ5GPAB/p1674774391650909