### PR TITLE
chore: add heartbeats to topic subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.vscode

--- a/proto/cachepubsub.proto
+++ b/proto/cachepubsub.proto
@@ -80,12 +80,16 @@ message _SubscriptionItem {
   oneof kind {
     // The subscription has yielded an item you previously published.
     _TopicItem item = 1;
+
     // Momento wants to let you know we detected some possible inconsistency at this
     // point in the subscription stream.
     //
     // A lack of a discontinuity does not mean the subscription is guaranteed to be
     // strictly perfect, but the presence of a discontinuity is very likely to
     _Discontinuity discontinuity = 2;
+
+    // The stream is still working, there's nothing to see here.
+    _Heartbeat heartbeat = 3;
   }
 }
 
@@ -123,4 +127,14 @@ message _Discontinuity {
   uint64 last_topic_sequence = 1;
   // The new topic sequence number after which TopicItems will ostensibly resume.
   uint64 new_topic_sequence = 2;
+}
+
+// A message from Momento for when we want to reassure clients or frameworks that a
+// Subscription is still healthy.
+// These are synthetic meta-events and do not increase the topic sequence count.
+// Different subscribers may receive a different cadence of heartbeat, and no guarantee
+// is made about the cadence or even presence or absence of heartbeats in a stream.
+// They are a tool for helping ensure that socket timeouts and the like don't impact
+// subscriptions you may care about, but that aren't receiving a substantial publish rate.
+message _Heartbeat {
 }


### PR DESCRIPTION
A tool for helping to make long-lived subscriptions to low-rate
topics.
