### PR TITLE
feat: Add ordering for Sorted Set Rank operation

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -562,8 +562,22 @@ message _SortedSetIncrementResponse {
 }
 
 message _SortedSetGetRankRequest {
+  enum Order {
+    ASCENDING = 0;
+    DESCENDING = 1;
+  }
+
   bytes set_name = 1;
   bytes element_name = 2;
+  // The order in which sorted set will be sorted to determine the rank.
+  //
+  // When Order.ASCENDING is specified, will return the rank of the element
+  // when sorted set scores are ordered from low to high. This is the default
+  // when no Order isn't specified.
+  //
+  // When Order.DESCENDING is specified, will return the rank of the element
+  // when sorted set scores are ordered from high to low.
+  Order order = 3;
 }
 
 message _SortedSetGetRankResponse {

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -583,6 +583,9 @@ message _SortedSetGetRankRequest {
 message _SortedSetGetRankResponse {
   message _RankResponsePart {
     ECacheResult result = 1;
+    // Rank is 0-based i.e. when sort order is descending the rank of the
+    // element with the highest score will be 0. Similarly for ascending order,
+    // element with the lowest score will have rank 0.
     uint64 rank = 2;
   }
 

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -573,7 +573,7 @@ message _SortedSetGetRankRequest {
   //
   // When Order.ASCENDING is specified, will return the rank of the element
   // when sorted set scores are ordered from low to high. This is the default
-  // when no Order isn't specified.
+  // when no Order is specified.
   //
   // When Order.DESCENDING is specified, will return the rank of the element
   // when sorted set scores are ordered from high to low.


### PR DESCRIPTION
Adds an optional Order enum to the SortedSetRank Request. Given an element whose rank needs to be determined, the new ordering parameter determines how the sorted set will be ordered when looking for an element's presence and its rank.

When Ascending order is specified the rank of the element will be its index when the sorted set scores are orderd from low to high. For descending order, the rank of the element is its index when the sorted set scores are ordered from high to low.