### PR TITLE
feat: add protos for generating secure tokens

### DIFF
--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -15,6 +15,7 @@ service ScsControl {
   rpc CreateSigningKey (_CreateSigningKeyRequest) returns (_CreateSigningKeyResponse) {}
   rpc RevokeSigningKey (_RevokeSigningKeyRequest) returns (_RevokeSigningKeyResponse) {}
   rpc ListSigningKeys (_ListSigningKeysRequest) returns (_ListSigningKeysResponse) {}
+  rpc GenerateToken(_GenerateTokenRequest) returns (_GenerateTokenResponse) {}
 }
 
 message _DeleteCacheRequest {
@@ -82,4 +83,17 @@ message _FlushCacheRequest {
 
 message _FlushCacheResponse {
 
+}
+
+message _GenerateTokenRequest {
+  string session_token = 1;
+  uint64 expire_at = 2;
+  string subject = 3;
+}
+
+message _GenerateTokenResponse {
+  string api_token = 1;
+  string refresh_token = 2;
+  string endpoint = 3;
+  uint64 valid_until = 4;
 }

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -89,7 +89,6 @@ message _FlushCacheResponse {
 message _GenerateTokenRequest {
   // how many seconds do you want the api token to be valid for?
   uint32 valid_for_seconds = 1;
-  string subject = 2;
 }
 
 message _GenerateTokenResponse {

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -87,10 +87,9 @@ message _FlushCacheResponse {
 }
 
 message _GenerateTokenRequest {
-  string session_token = 1;
   // how many seconds do you want the api token to be valid for?
-  uint32 valid_for_seconds = 2;
-  string subject = 3;
+  uint32 valid_for_seconds = 1;
+  string subject = 2;
 }
 
 message _GenerateTokenResponse {

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -15,6 +15,7 @@ service ScsControl {
   rpc CreateSigningKey (_CreateSigningKeyRequest) returns (_CreateSigningKeyResponse) {}
   rpc RevokeSigningKey (_RevokeSigningKeyRequest) returns (_RevokeSigningKeyResponse) {}
   rpc ListSigningKeys (_ListSigningKeysRequest) returns (_ListSigningKeysResponse) {}
+  // api for programatically generating api and refresh tokens
   rpc GenerateToken(_GenerateTokenRequest) returns (_GenerateTokenResponse) {}
 }
 
@@ -87,13 +88,19 @@ message _FlushCacheResponse {
 
 message _GenerateTokenRequest {
   string session_token = 1;
-  uint64 expire_at = 2;
+  // how many seconds do you want the api token to be valid for?
+  uint32 valid_for_seconds = 2;
   string subject = 3;
 }
 
 message _GenerateTokenResponse {
+  // the token that will be used to make requests against Momento backend
   string api_token = 1;
+  // the token that will allow the api token to be refreshed, which will
+  // give you back a new refresh and api token
   string refresh_token = 2;
+  // the Momento endpoint that this token is allowed to make requests against
   string endpoint = 3;
+  // epoch seconds when the api token expires
   uint64 valid_until = 4;
 }


### PR DESCRIPTION
This pr adds a new api to the control plane to generate an api token/refresh token for users to recieve tokens that have an expiration date.

signing up via the cli will look something like

```
momento token generate --endpoint <endpoint> --expiration 30d
```

it will return
```
{
  "api_token": <JWT>,
  "refresh_token": <refresh token>,
  "endpoint": "cell-4-us-west-2.a.prod.momentohq.com",
  "valid_until": <epoch seconds when token expires> 
}
```