### PR TITLE
feat: use oneof to determine if token has expiry

### DIFF
--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -104,11 +104,13 @@ message _GenerateTokenRequest {
 }
 
 message _GenerateTokenResponse {
-  // the base64 encoded (api_key, endpoint)
+  // the token that will be used to make requests against Momento backend
   string api_token = 1;
   // the token that will allow the api token to be refreshed, which will
   // give you back a new refresh and api token
   string refresh_token = 2;
+  // the Momento endpoint that this token is allowed to make requests against
+  string endpoint = 3;
   // epoch seconds when the api token expires
-  uint64 valid_until = 3;
+  uint64 valid_until = 4;
 }

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -87,8 +87,18 @@ message _FlushCacheResponse {
 }
 
 message _GenerateTokenRequest {
-  // how many seconds do you want the api token to be valid for?
-  uint32 valid_for_seconds = 1;
+  message NeverExpire {}
+  message ExpireIn {
+    // how many seconds do you want the api token to be valid for?
+    uint32 valid_for_seconds = 1;
+  }
+
+  oneof expiry {
+    NeverExpire never = 2;
+    ExpireIn expire_in = 3;
+  }
+
+  reserved 1;
 }
 
 message _GenerateTokenResponse {

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -87,15 +87,17 @@ message _FlushCacheResponse {
 }
 
 message _GenerateTokenRequest {
-  message NeverExpire {}
-  message ExpireIn {
+  // generate a token that will never expire
+  message Never {}
+  // generate a token that has an expiry
+  message Expires {
     // how many seconds do you want the api token to be valid for?
     uint32 valid_for_seconds = 1;
   }
 
   oneof expiry {
-    NeverExpire never = 2;
-    ExpireIn expire_in = 3;
+    Never never = 2;
+    Expires expires = 3;
   }
 
   reserved 1;

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -104,7 +104,7 @@ message _GenerateApiTokenRequest {
 }
 
 message _GenerateApiTokenResponse {
-  // the token that will be used to make requests against Momento backend
+  // the api key used for authentication against Momento backend
   string api_key = 1;
   // the token that will allow the api token to be refreshed, which will
   // give you back a new refresh and api token

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -104,13 +104,11 @@ message _GenerateTokenRequest {
 }
 
 message _GenerateTokenResponse {
-  // the token that will be used to make requests against Momento backend
+  // the base64 encoded (api_key, endpoint)
   string api_token = 1;
   // the token that will allow the api token to be refreshed, which will
   // give you back a new refresh and api token
   string refresh_token = 2;
-  // the Momento endpoint that this token is allowed to make requests against
-  string endpoint = 3;
   // epoch seconds when the api token expires
-  uint64 valid_until = 4;
+  uint64 valid_until = 3;
 }

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -16,7 +16,7 @@ service ScsControl {
   rpc RevokeSigningKey (_RevokeSigningKeyRequest) returns (_RevokeSigningKeyResponse) {}
   rpc ListSigningKeys (_ListSigningKeysRequest) returns (_ListSigningKeysResponse) {}
   // api for programatically generating api and refresh tokens
-  rpc GenerateToken(_GenerateTokenRequest) returns (_GenerateTokenResponse) {}
+  rpc GenerateApiToken(_GenerateApiTokenRequest) returns (_GenerateApiTokenResponse) {}
 }
 
 message _DeleteCacheRequest {
@@ -86,7 +86,7 @@ message _FlushCacheResponse {
 
 }
 
-message _GenerateTokenRequest {
+message _GenerateApiTokenRequest {
   // generate a token that will never expire
   message Never {}
   // generate a token that has an expiry
@@ -103,9 +103,9 @@ message _GenerateTokenRequest {
   reserved 1;
 }
 
-message _GenerateTokenResponse {
+message _GenerateApiTokenResponse {
   // the token that will be used to make requests against Momento backend
-  string api_token = 1;
+  string api_key = 1;
   // the token that will allow the api token to be refreshed, which will
   // give you back a new refresh and api token
   string refresh_token = 2;


### PR DESCRIPTION
After a back and forth, we have decided to use oneof when generating api tokens, to determine if a token expires or not. Previously, we were going to have `valid_for_seconds = 0` to mean that the token would never expire. This change just makes it much more explicit