### PR TITLE
fix: Add missing go_package options.

### DIFF
--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+option go_package = "github.com/momentohq/client-sdk-go;client_sdk_go";
 option java_multiple_files = true;
 option java_package = "momento.auth";
 

--- a/proto/cacheping.proto
+++ b/proto/cacheping.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+option go_package = "github.com/momentohq/client-sdk-go;client_sdk_go";
 option java_multiple_files = true;
 option java_package = "grpc.cache_client";
 option csharp_namespace = "Momento.Protos.CachePing";


### PR DESCRIPTION
A couple proto files were mising the `go_package` option. We keep having to put it back when copying the protos to Go.