### PR TITLE
feat: add UpdateTtl API

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -22,6 +22,7 @@ service Scs {
   rpc SetIfNotExists (_SetIfNotExistsRequest) returns (_SetIfNotExistsResponse) {}
   rpc Delete (_DeleteRequest) returns (_DeleteResponse) {}
   rpc Increment (_IncrementRequest) returns (_IncrementResponse) {}
+  rpc UpdateTtl (_UpdateTtlRequest) returns (_UpdateTtlResponse) {}
 
   rpc DictionaryGet (_DictionaryGetRequest) returns (_DictionaryGetResponse) {}
   rpc DictionaryFetch (_DictionaryFetchRequest) returns (_DictionaryFetchResponse) {}
@@ -128,6 +129,33 @@ message _IncrementRequest {
 message _IncrementResponse {
   // The value stored after the increment operation.
   int64 value = 1;
+}
+
+
+message _UpdateTtlRequest {
+  bytes cache_key = 1;
+  oneof update_ttl {
+    // Sets the ttl to this value only if it is an increase compared to the existing ttl
+    uint64 increase_to_milliseconds = 2;
+    // Sets the ttl to this value only if it is a decrease compared to the existing ttl
+    uint64 decrease_to_milliseconds = 3;
+    // Sets the ttl to this value unconditionally
+    uint64 overwrite_to_milliseconds = 4;
+  }
+}
+
+message _UpdateTtlResponse {
+  // Indicates that the ttl was applied.
+  message _Set{}
+  // Indicates that the ttl was not applied due to a failed condition.
+  message _NotSet{}
+  // Indicates that the key did not exist.
+  message _Missing{}
+  oneof result {
+    _Set set = 1;
+    _NotSet not_set = 2;
+    _Missing missing = 3;
+  }
 }
 
 message _DictionaryGetRequest {


### PR DESCRIPTION
Adds new API UpdateTtl.

This API allows for setting the TTL for a given key to a specified value.

This can be performed unconditionally, or optionally predicated on one of the following conditions:
- The new TTL would be an increase compared to the existing TTL
- The new TTL would be a decrease compared to the existing TTL

The new API returns a response indicating whether the key was present, and if so, whether the new TTL was applied.