### PR TITLE
feat: add change detection so releases can be conditional

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,6 +27,25 @@ jobs:
         id: release
         run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
 
+  # Detect changes to specific directories to let downstream release jobs run conditionally
+  changes:
+    name: Detect changes in last commit
+    runs-on: ubuntu-latest
+    outputs:
+      protos: ${{ steps.filter.outputs.protos }}
+      java: ${{ steps.filter.outputs.java }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          base: main
+          filters: |
+            protos:
+              - 'protos/**'
+            java:
+              - 'java/**'
+
   publish_javascript:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -113,7 +132,8 @@ jobs:
 
   publish_java:
     runs-on: ubuntu-latest
-    needs: release
+    needs: [release, changes]
+    if: ${{ needs.changes.outputs.protos == 'true' || needs.changes.outputs.java == 'true' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Add a job that detects changes since the last commit and currently outputs whether the protos and java directories have changed.

Make the publish_java job conditional on either protos or java changing. This will prevent a change to another language's code from making a redundant release, but it means not every version increment will have a corresponding java release.