### PR TITLE
feat: custom message extensions

### DIFF
--- a/proto/cachepubsub.proto
+++ b/proto/cachepubsub.proto
@@ -1,11 +1,14 @@
 syntax = "proto3";
 
+import "extensions.proto";
+
 option go_package = "github.com/momentohq/client-sdk-go;client_sdk_go";
 option java_multiple_files = true;
 option java_package = "grpc.cache_client.pubsub";
 option csharp_namespace = "Momento.Protos.CacheClient.Pubsub";
 
 package cache_client.pubsub;
+
 
 // For working with topics in a cache.
 // Momento topics are conceptually located on a cache. They are best-effort multicast.
@@ -47,6 +50,8 @@ message _Empty {}
 
 // A value to publish through a topic.
 message _PublishRequest {
+  option (retry_semantic) = NotRetryable;
+
   // Cache namespace for the topic to which you want to send the value.
   string cache_name = 1;
   // The literal topic name to which you want to send the value.
@@ -58,6 +63,8 @@ message _PublishRequest {
 
 // A description of how you want to subscribe to a topic.
 message _SubscriptionRequest {
+  option (retry_semantic) = Retryable;
+
   // Cache namespace for the topic to which you want to subscribe.
   string cache_name = 1;
 

--- a/proto/extensions.proto
+++ b/proto/extensions.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/momentohq/client-sdk-go;client_sdk_go";
+option java_package = "grpc.extensions";
+option csharp_namespace = "Momento.Protos.Extensions";
+
+// A hint so you can decide a little more in the abstract "can this be retried?""
+enum RetrySemantic {
+    // Never retry this message without telling the user. (you should infer this as the default)
+    NotRetryable = 0;
+    // You can retry this without surfacing an error to the user.
+    Retryable = 1;
+}
+
+extend google.protobuf.MessageOptions {
+    // Can this message be re-driven without an error?
+    RetrySemantic retry_semantic = 50000;
+}


### PR DESCRIPTION
For dynamic inspection of messages, the inaugural extension is just
a retry semantic. The quality of retryability is  a little different
from idempotence. Each message may choose if we think it should be
automatically retried independently of whether or not it pedantically
matches a mathematical definition.
