### PR TITLE
fix: remove ts files from bundled code for js-web

### DIFF
--- a/javascript-web/.gitignore
+++ b/javascript-web/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 **/*.d.ts
 index.js
+src

--- a/javascript-web/generate_protos.sh
+++ b/javascript-web/generate_protos.sh
@@ -23,7 +23,7 @@ rm -f $plugin
 curl -L https://github.com/grpc/grpc-web/releases/download/$version/protoc-gen-grpc-web-$version-$platform -o $plugin
 chmod +x $plugin
 
-out=./dist
+out=./src
 rm -rf $out
 mkdir $out
 

--- a/javascript-web/index.ts
+++ b/javascript-web/index.ts
@@ -1,4 +1,4 @@
-export * as cache from './dist/CacheclientServiceClientPb'
-export * as control from './dist/ControlclientServiceClientPb'
-export * as auth from './dist/AuthServiceClientPb'
-export * as ping from './dist/CachepingServiceClientPb'
+export * as cache from './src/CacheclientServiceClientPb'
+export * as control from './src/ControlclientServiceClientPb'
+export * as auth from './src/AuthServiceClientPb'
+export * as ping from './src/CachepingServiceClientPb'

--- a/javascript-web/package.json
+++ b/javascript-web/package.json
@@ -22,8 +22,6 @@
   "dependencies": {
   },
   "files": [
-    "dist",
-    "index.d.ts",
-    "index.js"
+    "dist"
   ]
 }

--- a/javascript-web/package.json
+++ b/javascript-web/package.json
@@ -2,8 +2,8 @@
   "name": "@gomomento/generated-types-webtext",
   "description": "Types for Momento services",
   "version": "0.0.1",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/momentohq/client_protos"

--- a/javascript-web/tsconfig.json
+++ b/javascript-web/tsconfig.json
@@ -6,7 +6,8 @@
         "esModuleInterop": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
-        "declaration": true
+        "declaration": true,
+        "outDir": "dist"
     },
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "Recommended",


### PR DESCRIPTION
This change is the same as https://github.com/momentohq/client-protos/pull/157, but for the grpc-web sdk. We no longer are bundling the `.ts` files in the package, and just bundling the `.d.ts` and `.js` files