### PR TITLE
chore: generate code for pubsub

### DIFF
--- a/javascript-web/generate_protos.sh
+++ b/javascript-web/generate_protos.sh
@@ -34,8 +34,8 @@ mkdir $out
 
 protoc -I=../proto -I=/usr/local/include \
   --js_out=import_style=commonjs:$out \
-  cacheclient.proto controlclient.proto auth.proto cacheping.proto
+  cacheclient.proto controlclient.proto auth.proto cacheping.proto cachepubsub.proto
 
 protoc -I=../proto -I=/usr/local/include \
   --grpc-web_out=import_style=typescript,mode=grpcwebtext:$out \
-  cacheclient.proto controlclient.proto auth.proto cacheping.proto
+  cacheclient.proto controlclient.proto auth.proto cacheping.proto cachepubsub.proto


### PR DESCRIPTION
This commit adds `cachepubsub.proto` into the `generate_protos.sh` script.