### PR TITLE
feat: add permissions model to the auth token request proto

### DIFF
--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -70,10 +70,17 @@ message _GenerateApiTokenRequest {
     }
 
     // Aliases for categories of functionality.
-    enum Role {
-      PermitNone = 0;
-      // Restricts access to apis that read and write data: No higher level resource description or modification.
-      ReadWrite = 1;
+    enum CacheRole {
+      CachePermitNone = 0;
+      // Restricts access to apis that read and write data from caches: No higher level resource description or modification.
+      CacheReadWrite = 1;
+    }
+
+    // Aliases for categories of functionality.
+    enum TopicRole {
+      TopicPermitNone = 0;
+      // Restricts access to apis that read and write data from topics: No higher level resource description or modification.
+      TopicReadWrite = 1;
     }
 
     string auth_token = 3;
@@ -82,14 +89,14 @@ message _GenerateApiTokenRequest {
     // on the request, then the token is assumed to have "SuperUser" permissions
     message Restrictions {
       message CacheRestrictions {
-        Role role = 1;
+        CacheRole role = 1;
         // eventually could scope this down to a specific cache name or key
         // string cache = "an example cache";
         // string caches = ["cache1", "cache2"]
       }
 
       message TopicsRestrictions {
-        Role role = 1;
+        TopicRole role = 1;
         // eventually could scope this down to a specific topic name
         // string topic = "an example topic";
         // string topics = ["topic1", "topic2"]

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -99,7 +99,7 @@ message _GenerateApiTokenRequest {
       TopicsRestrictions topic = 2;
     }
 
-    Permissions permissions = 4;
+    repeated Permissions permissions = 4;
 }
 
 message _GenerateApiTokenResponse {

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -95,8 +95,10 @@ message _GenerateApiTokenRequest {
         // string topics = ["topic1", "topic2"]
       }
 
-      CacheRestrictions cache = 1;
-      TopicsRestrictions topic = 2;
+      oneof kind {
+          CacheRestrictions cache = 1;
+          TopicsRestrictions topic = 2;
+      }
     }
 
     repeated Restrictions restrictions = 4;

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -78,9 +78,9 @@ message _GenerateApiTokenRequest {
 
     string auth_token = 3;
 
-    // Contains the permissions that the token will have for each of our services. If it doesn't exist
+    // Contains the restrictions that the token will have for each of our services. If it doesn't exist
     // on the request, then the token is assumed to have "SuperUser" permissions
-    message Permissions {
+    message Restrictions {
       message CacheRestrictions {
         Role role = 1;
         // eventually could scope this down to a specific cache name or key
@@ -99,7 +99,7 @@ message _GenerateApiTokenRequest {
       TopicsRestrictions topic = 2;
     }
 
-    repeated Permissions permissions = 4;
+    repeated Restrictions restrictions = 4;
 }
 
 message _GenerateApiTokenResponse {

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -69,8 +69,11 @@ message _GenerateApiTokenRequest {
         Expires expires = 2;
     }
 
+    // Aliases for categories of functionality.
     enum Role {
-      ReadWrite = 0;
+      PermitNone = 0;
+      // Restricts access to apis that read and write data: No higher level resource description or modification.
+      ReadWrite = 1;
     }
 
     string auth_token = 3;
@@ -78,22 +81,22 @@ message _GenerateApiTokenRequest {
     // Contains the permissions that the token will have for each of our services. If it doesn't exist
     // on the request, then the token is assumed to have "SuperUser" permissions
     message Permissions {
-      message CachePermissions {
+      message CacheRestrictions {
         Role role = 1;
         // eventually could scope this down to a specific cache name or key
         // string cache = "an example cache";
         // string caches = ["cache1", "cache2"]
       }
 
-      message TopicsPermissions {
+      message TopicsRestrictions {
         Role role = 1;
         // eventually could scope this down to a specific topic name
         // string topic = "an example topic";
         // string topics = ["topic1", "topic2"]
       }
 
-      CachePermissions cache = 1;
-      TopicsPermissions topic = 2;
+      CacheRestrictions cache = 1;
+      TopicsRestrictions topic = 2;
     }
 
     Permissions permissions = 4;

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -69,8 +69,34 @@ message _GenerateApiTokenRequest {
         Expires expires = 2;
     }
 
-    // session token recieved from `momento login` command
-    string session_token = 3;
+    enum Role {
+      ReadWrite = 0;
+    }
+
+    string auth_token = 3;
+
+    // Contains the permissions that the token will have for each of our services. If it doesn't exist
+    // on the request, then the token is assumed to have "SuperUser" permissions
+    message Permissions {
+      message CachePermissions {
+        Role role = 1;
+        // eventually could scope this down to a specific cache name or key
+        // string cache = "an example cache";
+        // string caches = ["cache1", "cache2"]
+      }
+
+      message TopicsPermissions {
+        Role role = 1;
+        // eventually could scope this down to a specific topic name
+        // string topic = "an example topic";
+        // string topics = ["topic1", "topic2"]
+      }
+
+      CachePermissions cache = 1;
+      TopicsPermissions topic = 2;
+    }
+
+    Permissions permissions = 4;
 }
 
 message _GenerateApiTokenResponse {


### PR DESCRIPTION
This pr allows us to assign specific permissions to an auth token. v1 api tokens created without this `permissions` claim will be treated as `SuperUser` tokens with full permissions. Eventually, we will probably add additional restrictions to support more granular permissions

```
permissions: {
  cache: {
    role: readwrite

    [future stuff]
    key: base64?,
    key_utf8: string?,
    key_hash: sha1?,
    apis: ...
  },
  topic: {
    role: readwrite,

    [future stuff]
    topic: "if this is here it's limited to this topic"
  }
}
```

We will also add more roles in the future. MVP is to get a token that has data plane read/write access, so it is currently the only role we need. More details can be found in the notion doc https://www.notion.so/momentohq/Authz-67866217f45a4f3dbaf4c89cade335e9