### PR TITLE
fix: remove gitignore during rust publish

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -292,6 +292,26 @@ jobs:
           popd
         shell: bash
 
+      - name: Remove crates publish blocker
+        run: |
+          set -e
+          set -x
+          pushd rust/momento-protos/src
+            echo Removing .gitignore file so cargo publish picks up the generated proto *.rs files.
+            echo Cargo publish respects .gitignore, but we use that file to help developers changing protos.
+            echo Once we're on github and publishing, that file's presence blocks us from publishing the
+            echo generated protos. Since that is what we are trying to do, we have to remove it during the
+            echo github publish.
+            echo Note that it's still helpful to have it in local clones, as you can still generate your protos
+            echo and inspect the output over here in momento-protos/src without fear of accidentally submitting
+            echo locally generated source files. This is a publish-time concern only!
+            echo In case you're curious, we're doing all of this so end users of the momento client sdk do not
+            echo need to have protoc installed solely on our account.
+            ls -alh
+            rm .gitignore
+          popd
+        shell: bash
+
       - name: Release
         env:
           # TODO: Match the token with https://github.com/momentohq/client-sdk-rust/blob/main/.github/workflows/cd.yml


### PR DESCRIPTION
per the comment, this is an attempt to make cargo publish actually
pick up our generated source _without_ also making that generated
source either [1] dependent on developer protoc installations or [2]
vulnerable to easy git commit -a mistakes.
