### PR TITLE
feat: proto changes for fine grained authorization

### DIFF
--- a/install_protoc.sh
+++ b/install_protoc.sh
@@ -4,17 +4,22 @@ set -x
 
 VERSION=3.18.1
 
-sudo apt-get -y install zip tree
-curl -L https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/protoc-$VERSION-linux-x86_64.zip -o protoc.zip
-unzip -o protoc.zip -d protoc
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # Install protoc for local development on MacOS (requires Homebrew)
+  brew install zip tree
+  PROTOC_ZIP=protoc-$VERSION-osx-x86_64.zip
+else # Linux
+  sudo apt-get -y install zip tree
+  PROTOC_ZIP=protoc-$VERSION-linux-x86_64.zip
+fi
 
-mkdir temp
-pushd temp
-  curl -L https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/protoc-$VERSION-linux-x86_64.zip -o protoc.zip
-  unzip -o protoc.zip -d protoc
-  sudo mv protoc/bin/* /usr/local/bin/
-  sudo mv protoc/include/* /usr/local/include/
-popd
-rm -rf temp
+curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/$PROTOC_ZIP
+sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+sudo chmod a+rx /usr/local/bin/protoc
+sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
+sudo chmod -R a+rx /usr/local/include/google
+rm $PROTOC_ZIP
 
 tree /usr/local/include/google
+echo "Installed protoc $VERSION"
+protoc --version

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,6 +1,5 @@
 # Generating definitions
 ```bash
 npm install
-mkdir dist
-PATH=node_modules/protoc-gen-ts/bin/:$PATH protoc -I=../proto --ts_out=dist cacheclient.proto controlclient.proto cachepubsub.proto
+./generate_protos.sh
 ```

--- a/javascript/generate_protos.sh
+++ b/javascript/generate_protos.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
 set -x
-
-PATH=node_modules/protoc-gen-ts/bin/:$PATH protoc -I=../proto -I=/usr/local/include --ts_out=src cacheclient.proto controlclient.proto cachepubsub.proto auth.proto cacheping.proto
+TS_OUT=./src
+rm -rf $TS_OUT
+mkdir $TS_OUT
+protoc --plugin=protoc-gen-ts=node_modules/protoc-gen-ts/bin/protoc-gen-ts.js -I=../proto -I=/usr/local/include --ts_out=$TS_OUT cacheclient.proto controlclient.proto cachepubsub.proto auth.proto cacheping.proto

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@gomomento/generated-types",
       "version": "0.0.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "1.8.14",
         "@types/google-protobuf": "3.15.6",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rm -rf dist && mkdir -p src && ./generate_protos.sh && cp index.ts src/ && tsc"
+    "build": "rm -rf dist && ./generate_protos.sh && cp index.ts src/ && tsc"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -74,6 +74,8 @@ message _GenerateApiTokenRequest {
       CachePermitNone = 0;
       // Restricts access to apis that read and write data from caches: No higher level resource description or modification.
       CacheReadWrite = 1;
+      // Restricts access to apis that read from caches: No higher level resource description or modification.
+      CacheReadOnly = 2;
     }
 
     // Aliases for categories of functionality.
@@ -81,6 +83,8 @@ message _GenerateApiTokenRequest {
       TopicPermitNone = 0;
       // Restricts access to apis that read and write data from topics: No higher level resource description or modification.
       TopicReadWrite = 1;
+      // Restricts access to apis that read from topics: No higher level resource description or modification.
+      TopicReadOnly = 2;
     }
 
     string auth_token = 3;
@@ -106,12 +110,31 @@ message _GenerateApiTokenRequest {
         TopicPermissions topic_permissions = 2;
       }
 
+      message Any {}
+
+      message CacheResource {
+        oneof kind {
+          Any any = 1;
+          string cache_name = 2;
+        }
+      }
+
       message CachePermissions {
         CacheRole role = 1;
+        CacheResource cache = 2;
+      }
+
+      message TopicResource {
+        oneof kind {
+          Any any = 1;
+          string topic_name = 2;
+        }
       }
 
       message TopicPermissions {
         TopicRole role = 1;
+        CacheResource cache = 2;
+        TopicResource topic = 3;
       }
     }
 


### PR DESCRIPTION
- Adds ReadOnly role types for Cache and Topic permissions
- Permissions can specify all caches/topics (`Any`) or a specific cache/topic name. This can be extended in future to support partial matches.
- I had to change some scripts because the existing ones did not work on my Mac.