### PR TITLE
fix: Use commonjs_strict import_type to avoid Functions in generated code

### DIFF
--- a/javascript-web/README.md
+++ b/javascript-web/README.md
@@ -36,5 +36,5 @@ if (getResult.getResult() === ECacheResult.HIT) {
 
 # Generating definitions
 ```bash
-./generate_protos.sh [osx, linux, windows]
+./generate_protos.sh
 ```

--- a/javascript-web/generate_protos.sh
+++ b/javascript-web/generate_protos.sh
@@ -2,26 +2,22 @@
 set -e
 set -x
 
-if [ $# -lt 1 ]; then
-  echo usage: $0 osx  [osx, linux, windows]
-  exit 1
-fi
-if [ $1 == 'osx' ]; then
+if [[ "$OSTYPE" == "darwin"* ]]; then
   platform='darwin-x86_64'
-elif [ $1 == 'linux' ]; then
+elif [[ "$OSTYPE" == "linux"* ]]; then
   platform='linux-x86_64'
-elif [ $1 == 'windows' ]; then
+elif [[ "$OSTYPE" == "cygwin"* || "$OSTYPE" == "msys"* ]]; then
   platform='windows-x86_64'
 else
-  echo usage: $0 osx  [osx, linux, windows]
+  echo "Unknown OS: $OSTYPE"
   exit 1
 fi
 
 version='1.3.1'
 plugin='/usr/local/bin/protoc-gen-grpc-web'
-rm -f $plugin
-curl -L https://github.com/grpc/grpc-web/releases/download/$version/protoc-gen-grpc-web-$version-$platform -o $plugin
-chmod +x $plugin
+sudo rm -f $plugin
+sudo curl -L https://github.com/grpc/grpc-web/releases/download/$version/protoc-gen-grpc-web-$version-$platform -o $plugin
+sudo chmod a+x $plugin
 
 out=./src
 rm -rf $out
@@ -32,10 +28,64 @@ mkdir $out
 # brew link --overwrite protobuf@3
 # https://github.com/protocolbuffers/protobuf-javascript/issues/127#issuecomment-1204202844
 
+# The `--js_out` plugin will generate JavaScript code (`echo_pb.js`), and the
+# `-grpc-web_out` plugin will generate a TypeScript definition file for it
+# (`echo_pb.d.ts`). This is a temporary hack until the `--js_out` supports
+# TypeScript itself. See https://github.com/grpc/grpc-web/blob/7c528784576abbbfd05eb6085abb8c319d76ab05/README.md?plain=1#L246
+
+# Ramya: We need strict commonjs to allow Cloudflare workers to run the web sdk.
+# After changing to commonjs_strict, the web SDK will build but unit tests and integ tests fail with 
+# ```
+# Test suite failed to run
+#    TypeError: Cannot read properties of undefined (reading 'Never')
+#
+#       7 | } from '@gomomento/generated-types-webtext/dist/auth_pb';
+#       8 | import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
+#    >  9 | import Never = _GenerateApiTokenRequest.Never;
+#         |                                         ^
+#      10 | import Expires = _GenerateApiTokenRequest.Expires;
+#      11 | import {
+#      12 |   CredentialProvider,
+
+#      at Object.<anonymous> (src/internal/auth-client.ts:9:41)
+#      at Object.<anonymous> (src/auth-client.ts:5:1)
+#      at Object.<anonymous> (src/index.ts:2:1)
+#      at Object.<anonymous> (test/integration/integration-setup.ts:13:1)
+#      at Object.<anonymous> (test/integration/shared/auth-client.test.ts:2:1)
+# ```
+# I believe this is related to https://github.com/protocolbuffers/protobuf-javascript/issues/40
+# From a hint in https://medium.com/expedia-group-tech/the-weird-world-of-grpc-tooling-for-node-js-part-2-daafed94cc32,
+# I found that removing the `package <pkg-name>` from the protos gives us the JS exports we want.
+# Removing the package permanently is not possible now because it is part of the GRPC method descriptor.
+# So we do a terrible hack to comment out the package declaration before generating the JS types,
+# but add them back before generating the GRPC web bindings
+
+proto_file_list=" extensions.proto cacheclient.proto controlclient.proto auth.proto cacheping.proto cachepubsub.proto "
+
+echo "Commenting out package declarations"
+for f in $proto_file_list
+do
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' 's/^\s*package \(.*\)/\/\/package \1/g' ../proto/${f}
+  else
+    sed -i 's/^\s*package \(.*\)/\/\/package \1/g' ../proto/${f}
+  fi
+done
+
 protoc -I=../proto -I=/usr/local/include \
-  --js_out=import_style=commonjs:$out \
-  extensions.proto cacheclient.proto controlclient.proto auth.proto cacheping.proto cachepubsub.proto
+  --js_out=import_style=commonjs_strict:$out \
+  ${proto_file_list}
+
+echo "Uncommenting package declarations"
+for f in $proto_file_list
+do
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' 's/^\/\/package \(.*\)/package \1/g' ../proto/${f}
+  else
+    sed -i 's/^\/\/package \(.*\)/package \1/g' ../proto/${f}
+  fi
+done
 
 protoc -I=../proto -I=/usr/local/include \
   --grpc-web_out=import_style=typescript,mode=grpcwebtext:$out \
-  extensions.proto cacheclient.proto controlclient.proto auth.proto cacheping.proto cachepubsub.proto
+  ${proto_file_list}

--- a/javascript-web/package-lock.json
+++ b/javascript-web/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       },
       "devDependencies": {
@@ -29,11 +28,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
       "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==",
       "dev": true
-    },
-    "node_modules/google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
     "node_modules/grpc-web": {
       "version": "1.4.2",
@@ -66,11 +60,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
       "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==",
       "dev": true
-    },
-    "google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
     "grpc-web": {
       "version": "1.4.2",

--- a/javascript-web/package-lock.json
+++ b/javascript-web/package-lock.json
@@ -1,13 +1,17 @@
 {
-  "name": "@gomomento/generated-types",
+  "name": "@gomomento/generated-types-webtext",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@gomomento/generated-types",
+      "name": "@gomomento/generated-types-webtext",
       "version": "0.0.1",
-      "license": "MIT",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-protobuf": "3.21.2",
+        "grpc-web": "1.4.2"
+      },
       "devDependencies": {
         "@tsconfig/node16": "1.0.2",
         "@types/node": "16.10.3",
@@ -25,6 +29,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
       "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==",
       "dev": true
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+    },
+    "node_modules/grpc-web": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.4.2.tgz",
+      "integrity": "sha512-gUxWq42l5ldaRplcKb4Pw5O4XBONWZgz3vxIIXnfIeJj8Jc3wYiq2O4c9xzx/NGbbPEej4rhI62C9eTENwLGNw=="
     },
     "node_modules/typescript": {
       "version": "4.4.3",
@@ -52,6 +66,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
       "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==",
       "dev": true
+    },
+    "google-protobuf": {
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+    },
+    "grpc-web": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.4.2.tgz",
+      "integrity": "sha512-gUxWq42l5ldaRplcKb4Pw5O4XBONWZgz3vxIIXnfIeJj8Jc3wYiq2O4c9xzx/NGbbPEej4rhI62C9eTENwLGNw=="
     },
     "typescript": {
       "version": "4.4.3",

--- a/javascript-web/package.json
+++ b/javascript-web/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rm -rf dist && mkdir dist && ./generate_protos.sh linux && cp index.ts src/ && tsc && cp src/*.d.ts ./dist && cp src/*.js ./dist"
+    "build": "rm -rf dist && mkdir dist && ./generate_protos.sh && cp index.ts src/ && tsc && cp src/*.d.ts ./dist && cp src/*.js ./dist",
+    "build-only": "rm -rf dist && mkdir dist && cp index.ts src/ && tsc && cp src/*.d.ts ./dist && cp src/*.js ./dist"
   },
   "author": "",
   "license": "Apache-2.0",
@@ -20,6 +21,8 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
+    "google-protobuf": "3.21.2",
+    "grpc-web": "1.4.2"
   },
   "files": [
     "dist"

--- a/javascript-web/package.json
+++ b/javascript-web/package.json
@@ -21,7 +21,6 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "google-protobuf": "3.21.2",
     "grpc-web": "1.4.2"
   },
   "files": [


### PR DESCRIPTION
This is a joint effort between @cprice404  and me to unblock Cloudflare.
Using the websdk in Cloudflare workers gives this error
```
service core:user:momento-cloudflare-worker-http: Uncaught Error: EvalError: Code generation from strings disallowed for this context
```
### Changes
- Changes to the `generate_protos.sh` script to support running `npm run build` on my mac and fixing permission errors when downloading the plugin
- Temporarily edit the proto files to remove package declarations from proto files to avoid runtime errors like below, which is similar to [this issue](https://github.com/protocolbuffers/protobuf-javascript/issues/40) / [tentative fix](https://github.com/protocolbuffers/protobuf/pull/8696/files#diff-ca4e383959a191d3a6fe7fd0a7494ef6bfad4935bab6788553f7cab9ca8666e1)
```
Test suite failed to run

    TypeError: Cannot read properties of undefined (reading 'Never')

       7 | } from '@gomomento/generated-types-webtext/dist/auth_pb';
       8 | import {cacheServiceErrorMapper} from '../errors/cache-service-error-mapper';
    >  9 | import Never = _GenerateApiTokenRequest.Never;
         |                                         ^
      10 | import Expires = _GenerateApiTokenRequest.Expires;
      11 | import {
      12 |   CredentialProvider,

      at Object.<anonymous> (src/internal/auth-client.ts:9:41)
      at Object.<anonymous> (src/auth-client.ts:5:1)
      at Object.<anonymous> (src/index.ts:2:1)
      at Object.<anonymous> (test/integration/integration-setup.ts:13:1)
      at Object.<anonymous> (test/integration/shared/auth-client.test.ts:2:1)
```
- Add back the package declaration otherwise we run into 
```
Integration tests for dictionary operations › #dictionaryRemoveField › should remove a Uint8Array field

    Method not found: ScsControl/DeleteCache

      at new E (../../../client-protos/javascript-web/node_modules/grpc-web/index.js:21:1379)
      at Y (../../../client-protos/javascript-web/node_modules/grpc-web/index.js:57:40)
      at qc.<anonymous> (../../../client-protos/javascript-web/node_modules/grpc-web/index.js:55:270)
      at Jb (../../../client-protos/javascript-web/node_modules/grpc-web/index.js:33:182)
      at O (../../../client-protos/javascript-web/node_modules/grpc-web/index.js:32:614)
      at Ac (../../../client-protos/javascript-web/node_modules/grpc-web/index.js:46:68)
      at qc.Object.<anonymous>.n.W (../../../client-protos/javascript-web/node_modules/grpc-web/index.js:44:252)
      at qc.Object.<anonymous>.n.R (../../../client-protos/javascript-web/node_modules/grpc-web/index.js:44:231)
      at XMLHttpRequest.invokeTheCallbackFunction (node_modules/jsdom/lib/jsdom/living/generated/EventHandlerNonNull.js:14:28)
      at XMLHttpRequest.<anonymous> (node_modules/jsdom/lib/jsdom/living/helpers/create-event-accessor.js:35:32)
      at innerInvokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
      at invokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
      at XMLHttpRequestImpl._dispatch (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
      at fireAnEvent (node_modules/jsdom/lib/jsdom/living/helpers/events.js:18:36)
      at readyStateChange (node_modules/jsdom/lib/jsdom/living/xhr/XMLHttpRequest-impl.js:761:3)
      at EventEmitter.<anonymous> (node_modules/jsdom/lib/jsdom/living/xhr/XMLHttpRequest-impl.js:889:5)
      at Request.<anonymous> (node_modules/jsdom/lib/jsdom/living/xhr/xhr-utils.js:385:41)
      at IncomingMessage.<anonymous> (node_modules/jsdom/lib/jsdom/living/helpers/http-request.js:230:42)
```
### Testing
- Unit and integration tests passed against alpha
- tested successfully in cloudflare worker after adding a polyfill for XmlHttpRequest using `xhrsw`
