### PR TITLE
fix: Remove self-generated google common protos

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,6 +45,10 @@ jobs:
               - 'protos/**'
             java:
               - 'java/**'
+      - name: Debug Outputs
+        run: |
+          echo "Protos output: ${{ steps.filter.outputs.protos }}"
+          echo "Java output: ${{ steps.filter.outputs.java }}"
 
   publish_javascript:
     # The type of runner that the job will run on
@@ -133,7 +137,8 @@ jobs:
   publish_java:
     runs-on: ubuntu-latest
     needs: [release, changes]
-    if: ${{ needs.changes.outputs.protos == 'true' || needs.changes.outputs.java == 'true' }}
+    # Temporarily disable this while debugging conditional release action
+    #if: ${{ needs.changes.outputs.protos == 'true' || needs.changes.outputs.java == 'true' }}
 
     steps:
       - name: Checkout code

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -26,12 +26,14 @@ dependencies {
     implementation("io.grpc:grpc-api")
     implementation("io.grpc:grpc-protobuf")
     implementation("com.google.protobuf:protobuf-java")
+    implementation("com.google.api.grpc:proto-google-common-protos:2.9.0") // version pulled from protobuf-java
     implementation("com.google.guava:guava:31.1-android") // version pulled from protobuf-java
     compileOnly("javax.annotation:javax.annotation-api:1.3.2")
 
-    permitUsedUndeclared("com.google.api.grpc:proto-google-common-protos:2.9.0")
-
-    protobuf(files("../proto/"))
+    protobuf(files(fileTree("../proto") {
+        include("*.proto")
+        exclude("**/*/*.proto")
+    }))
 }
 
 java {
@@ -111,9 +113,10 @@ publishing {
                 }
                 developers {
                     developer {
-                        id.set("nand4011")
-                        name.set("Nate Anderson")
+                        id.set("momento")
+                        name.set("Momento")
                         organization.set("Momento")
+                        email.set("eng-deveco@momentohq.com")
                     }
                 }
                 scm {


### PR DESCRIPTION
Stop generating google common protos. A customer is getting conflicts because they are colliding with those in the proto-google-common-protos dependency.

Change java artifact developer to the generic momento dev to match the java SDK.

Temporarily disable conditional releases of the java protos and add debug statements because java appears to never be released.