### PR TITLE
feat: update grpc-js to 1.9

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -9,21 +9,21 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "1.8.17",
-        "@types/google-protobuf": "3.15.6",
+        "@grpc/grpc-js": "1.9.0",
         "google-protobuf": "3.21.2"
       },
       "devDependencies": {
         "@tsconfig/node16": "1.0.2",
+        "@types/google-protobuf": "3.15.6",
         "@types/node": "16.10.3",
         "protoc-gen-ts": "0.8.6",
         "typescript": "4.9.5"
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -113,7 +113,8 @@
     "node_modules/@types/google-protobuf": {
       "version": "3.15.6",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw=="
+      "integrity": "sha512-pYVNNJ+winC4aek+lZp93sIKxnXt5qMkuKmaqS3WGuTq0Bw1ZDYNBgzG5kkdtwcv+GmYJGo3yEg6z2cKKAiEdw==",
+      "dev": true
     },
     "node_modules/@types/long": {
       "version": "4.0.2",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -16,13 +16,13 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@tsconfig/node16": "1.0.2",
+    "@types/google-protobuf": "3.15.6",
     "@types/node": "16.10.3",
     "protoc-gen-ts": "0.8.6",
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@grpc/grpc-js": "1.8.17",
-    "@types/google-protobuf": "3.15.6",
+    "@grpc/grpc-js": "1.9.0",
     "google-protobuf": "3.21.2"
   },
   "files": [


### PR DESCRIPTION
This includes the following changes [from usptream](https://github.com/grpc/grpc-node/releases):

* Implement channel idle timeout and the channel option grpc.client_idle_timeout_ms (#2471)
* Implement gRFC A62: pick_first: sticky TRANSIENT_FAILURE and address order randomization (#2511)
* Fix premature leaving of context due to improper Http2ServerCallStream handling (#2501 contributed by @CedricKassen)
* Add channel option grpc-node.tls_enable_trace to enable Node TLS tracing (#2507)
* Cancel deadline timer on server when call is cancelled (#2508)

* Added grpc.experimental.createResolver

* Fix propagation of UNIMPLEMENTED error messages (#2528)
* Fix a crash when the channel option grpc.keepalive_permit_without_calls is set (#2519)
* Update keepalive behavior to more correctly handle short calls and long periods of inactivity (#2513)
* Fix reporting of call stacks in unary request errors (#2503)
*  Fix reporting of proxy info in channelz socket responses (#2503)
