### PR TITLE
feat: New cache item selector for per key permissions and role for write only

### DIFF
--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -76,6 +76,8 @@ message _GenerateApiTokenRequest {
       CacheReadWrite = 1;
       // Restricts access to apis that read from caches: No higher level resource description or modification.
       CacheReadOnly = 2;
+      // Doesn't allow conditional write APIs (SetIfNotExists, IncreaseTTL etc)
+      CacheWriteOnly = 3;
     }
 
     // Aliases for categories of functionality.
@@ -85,6 +87,8 @@ message _GenerateApiTokenRequest {
       TopicReadWrite = 1;
       // Restricts access to apis that read from topics: No higher level resource description or modification.
       TopicReadOnly = 2;
+      // Only publish allowed
+      TopicWriteOnly = 3;
     }
 
     string auth_token = 3;
@@ -118,12 +122,23 @@ message _GenerateApiTokenRequest {
         }
       }
 
+      message CacheItemSelector {
+        oneof kind {
+          bytes key = 1;
+          bytes key_prefix = 2;
+        }
+      }
+
       message CachePermissions {
         CacheRole role = 1;
         oneof cache {
           All all_caches = 2;
           CacheSelector cache_selector = 3;
-        } 
+        }
+        oneof cache_item {
+          All all_items = 4;
+          CacheItemSelector item_selector = 5;
+        }
       }
 
       message TopicSelector {


### PR DESCRIPTION
Two changes
- New write only option for Cache and Topic roles
- You can now specify a per cache item permissions, either by matching key, or key prefix

For full design info https://www.notion.so/momentohq/Fine-Grained-Access-Control-at-Cache-Item-granularity-89be02447a7e41689f17e3e750162e54