### PR TITLE
refactor: list indexes should return a list of index names

### DIFF
--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -39,7 +39,7 @@ message _ListIndexesRequest {
 }
 
 message _ListIndexesResponse {
-  repeated string indexes = 1;
+  repeated string index_names = 1;
 }
 
 message _DeleteCacheRequest {

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -36,16 +36,10 @@ message _DeleteIndexResponse {
 }
 
 message _ListIndexesRequest {
-  string next_token = 1;
 }
 
 message _ListIndexesResponse {
-  repeated _Index indexes = 1;
-  string next_token = 2;
-}
-
-message _Index {
-  string index_name = 1;
+  repeated string indexes = 1;
 }
 
 message _DeleteCacheRequest {


### PR DESCRIPTION
The previous version had a level of indirection between the list
indexes response and the index name. While that could allow for more
detail in the future, that detail belongs in a "describe index" rpc
and not "list indexes".
