### PR TITLE
chore: Add leaderboard definitions

### DIFF
--- a/proto/leaderboard.proto
+++ b/proto/leaderboard.proto
@@ -1,0 +1,192 @@
+syntax = "proto3";
+
+option go_package = "github.com/momentohq/client-sdk-go;client_sdk_go";
+option java_multiple_files = true;
+option java_package = "grpc.leaderboard";
+option csharp_namespace = "Momento.Protos.Leaderboard";
+
+package leaderboard;
+
+// Like a sorted set, but for leaderboards!
+//
+// Elements in a leaderboard are keyed by an ID, which is an unsigned 64 bit integer.
+// Scores are single-precision floating point numbers.
+//
+// Each ID can have only 1 score.
+//
+// For batchy, multi-element apis, limits are 8192 elements per api call.
+//
+// Scores are IEEE 754 single-precision floating point numbers. This has a few
+// implications you should be aware of, but the one most likely to affect you is that
+// below -16777216 and above 16777216, not all integers are able to be represented.
+service Leaderboard {
+  // Deletes a leaderboard. After this call, you're not incurring storage cost for this leaderboard anymore.
+  rpc DeleteLeaderboard(DeleteLeaderboardRequest) returns (Empty);
+
+  // Insert or update elements in a leaderboard. You can do up to 8192 elements per call.
+  // There is no partial failure: Upsert succeeds or fails.
+  rpc UpsertElements(UpsertElementsRequest) returns (Empty);
+
+  // Remove up to 8192 elements at a time from a leaderboard. Elements are removed by id.
+  rpc RemoveElements(RemoveElementsRequest) returns (Empty);
+
+  // Returns the length of a leaderboard in terms of ID count. 
+  rpc GetLeaderboardLength(GetLeaderboardLengthRequest) returns (GetLeaderboardLengthResponse);
+
+  // Get a range of elements.
+  // * Ordinal, 0-based rank.
+  // * Ascending order (0 is your lowest score).
+  // * Range can span up to 8192 elements.
+  // See RankRange for details about permissible ranges.
+  rpc GetByRankAsc(GetByRankRequest) returns (GetByRankResponse);
+
+  // Get a range of elements.
+  // * Ordinal, 0-based rank.
+  // * Descending order (0 is your highest score).
+  // * Range can span up to 8192 elements.
+  // See RankRange for details about permissible ranges.
+  rpc GetByRankDesc(GetByRankRequest) returns (GetByRankResponse);
+
+  // Get the rank of a particular id in the leaderboard.
+  // * Ordinal, 0-based rank.
+  // * Ascending order (0 is the lowest-scoring rank).
+  rpc GetRankAsc(GetRankRequest) returns (RankedElement);
+
+  // Get the rank of a particular id in the leaderboard.
+  // * Ordinal, 0-based rank.
+  // * Descending order (0 is the highest-scoring rank).
+  rpc GetRankDesc(GetRankRequest) returns (RankedElement);
+
+  // Get a range of elements by a score range.
+  // * Ordinal, 0-based rank.
+  // * Ascending order (0 is the lowest-scoring rank)
+  //
+  // You can request up to 8192 elements at a time. To page through many elements that all
+  // fall into a score range you can repeatedly invoke this api with the offset parameter.
+  rpc GetByScoreAsc(GetByScoreRequest) returns (GetByScoreResponse);
+
+  // Get a range of elements by a score range.
+  // * Ordinal, 0-based rank.
+  // * Descending order (0 is the highest-scoring rank)
+  //
+  // You can request up to 8192 elements at a time. To page through many elements that all
+  // fall into a score range you can repeatedly invoke this api with the offset parameter.
+  rpc GetByScoreDesc(GetByScoreRequest) returns (GetByScoreResponse);
+}
+
+// Leaderboards are made up of many of these.
+message Element {
+  // A player identifier, session identifier, browser identifier or whatever other kind of
+  // identifier you use for this scoreboard. The full unsigned 64 bit range is allowed here,
+  // between 0 and 2^63-1 inclusive.
+  // An id can only appear in a leaderboard one time. You can't have 2 scores for 1 player,
+  // unless that player has 2 ids!
+  uint64 id = 1;
+
+  // The value by which this element is sorted within the leaderboard.
+  float score = 2;
+}
+
+// Query APIs returning RankedElement offer the familiar Element id and score tuple, but they
+// also include the rank per the individual API's ranking semantic.
+message RankedElement {
+  uint64 id = 1;
+  float score = 2;
+  uint64 rank = 3;
+}
+
+// Query APIs using RankRange expect a limit of 8192 elements. Requesting a range wider than
+// that is expected to return an error.
+//
+// RankRange models half-open ranges: 0..4 refers to elements 0, 1, 2 and 3.
+//
+// Example permissible ranges:
+// * 0..8192
+// * 1..8193
+// * 123..8315
+// * 0..1
+// * 1..4
+// * 13..17
+//
+// Example error ranges:
+// * 0..0
+// * 4..3
+// * 0..8193
+message RankRange {
+  uint64 start_inclusive = 1;
+  uint64 end_exclusive = 2;
+}
+
+// Query APIs using ScoreRange may match more than the limit of 8192 elements. These apis will
+// include an offset and limit parameter pair, which can be used to page through score ranges
+// matching many elements.
+//
+// ScoreRange models half-open ranges: 0..4 refers to scores 0, 1.1234, 2.5 and 3.999.
+message ScoreRange {
+  // IEEE 754 single precision 32 bit floating point number.
+  // Momento does not support NaN or Inf in leaderboards.
+  float score_start = 1;
+  // IEEE 754 single precision 32 bit floating point number.
+  // Momento does not support NaN or Inf in leaderboards.
+  float score_end = 2;
+}
+
+message Empty {}
+
+message DeleteLeaderboardRequest {
+  string cache_name = 1;
+  string leaderboard = 2;
+}
+
+message GetLeaderboardLengthRequest {
+  string cache_name = 1;
+  string leaderboard = 2;
+}
+
+message GetLeaderboardLengthResponse {
+   uint64 count = 1;
+}
+
+message UpsertElementsRequest {
+  string cache_name = 1;
+  string leaderboard = 2;
+  // You can have up to 8192 elements in this list.
+  repeated Element elements = 3;
+}
+
+message GetByRankRequest {
+  string cache_name = 1;
+  string leaderboard = 2;
+  RankRange rank_range = 3;
+}
+
+message GetByRankResponse {
+  repeated RankedElement elements = 1;
+}
+
+message GetRankRequest {
+  string cache_name = 1;
+  string leaderboard = 2;
+  uint64 id = 3;
+}
+
+message RemoveElementsRequest {
+  string cache_name = 1;
+  string leaderboard = 2;
+  // You can have up to 8192 ids in this list.
+  repeated uint64 ids = 3;
+}
+
+message GetByScoreRequest {
+  string cache_name = 1;
+  string leaderboard = 2;
+  ScoreRange score_range = 3;
+  // Where should we start returning scores from in the elements within this range?
+  uint64 offset = 4;
+  // How many elements should we limit to returning? (8192 max)
+  uint64 limit_elements = 5;
+}
+
+message GetByScoreResponse {
+  repeated RankedElement elements = 1;
+}

--- a/proto/leaderboard.proto
+++ b/proto/leaderboard.proto
@@ -21,41 +21,41 @@ package leaderboard;
 // below -16777216 and above 16777216, not all integers are able to be represented.
 service Leaderboard {
   // Deletes a leaderboard. After this call, you're not incurring storage cost for this leaderboard anymore.
-  rpc DeleteLeaderboard(DeleteLeaderboardRequest) returns (Empty);
+  rpc DeleteLeaderboard(_DeleteLeaderboardRequest) returns (_Empty);
 
   // Insert or update elements in a leaderboard. You can do up to 8192 elements per call.
   // There is no partial failure: Upsert succeeds or fails.
-  rpc UpsertElements(UpsertElementsRequest) returns (Empty);
+  rpc UpsertElements(_UpsertElementsRequest) returns (_Empty);
 
   // Remove up to 8192 elements at a time from a leaderboard. Elements are removed by id.
-  rpc RemoveElements(RemoveElementsRequest) returns (Empty);
+  rpc RemoveElements(_RemoveElementsRequest) returns (_Empty);
 
   // Returns the length of a leaderboard in terms of ID count. 
-  rpc GetLeaderboardLength(GetLeaderboardLengthRequest) returns (GetLeaderboardLengthResponse);
+  rpc GetLeaderboardLength(_GetLeaderboardLengthRequest) returns (_GetLeaderboardLengthResponse);
 
   // Get a range of elements.
   // * Ordinal, 0-based rank.
   // * Ascending order (0 is your lowest score).
   // * Range can span up to 8192 elements.
   // See RankRange for details about permissible ranges.
-  rpc GetByRankAsc(GetByRankRequest) returns (GetByRankResponse);
+  rpc GetByRankAsc(_GetByRankRequest) returns (_GetByRankResponse);
 
   // Get a range of elements.
   // * Ordinal, 0-based rank.
   // * Descending order (0 is your highest score).
   // * Range can span up to 8192 elements.
   // See RankRange for details about permissible ranges.
-  rpc GetByRankDesc(GetByRankRequest) returns (GetByRankResponse);
+  rpc GetByRankDesc(_GetByRankRequest) returns (_GetByRankResponse);
 
   // Get the rank of a particular id in the leaderboard.
   // * Ordinal, 0-based rank.
   // * Ascending order (0 is the lowest-scoring rank).
-  rpc GetRankAsc(GetRankRequest) returns (RankedElement);
+  rpc GetRankAsc(_GetRankRequest) returns (_RankedElement);
 
   // Get the rank of a particular id in the leaderboard.
   // * Ordinal, 0-based rank.
   // * Descending order (0 is the highest-scoring rank).
-  rpc GetRankDesc(GetRankRequest) returns (RankedElement);
+  rpc GetRankDesc(_GetRankRequest) returns (_RankedElement);
 
   // Get a range of elements by a score range.
   // * Ordinal, 0-based rank.
@@ -63,7 +63,7 @@ service Leaderboard {
   //
   // You can request up to 8192 elements at a time. To page through many elements that all
   // fall into a score range you can repeatedly invoke this api with the offset parameter.
-  rpc GetByScoreAsc(GetByScoreRequest) returns (GetByScoreResponse);
+  rpc GetByScoreAsc(_GetByScoreRequest) returns (_GetByScoreResponse);
 
   // Get a range of elements by a score range.
   // * Ordinal, 0-based rank.
@@ -71,11 +71,11 @@ service Leaderboard {
   //
   // You can request up to 8192 elements at a time. To page through many elements that all
   // fall into a score range you can repeatedly invoke this api with the offset parameter.
-  rpc GetByScoreDesc(GetByScoreRequest) returns (GetByScoreResponse);
+  rpc GetByScoreDesc(_GetByScoreRequest) returns (_GetByScoreResponse);
 }
 
 // Leaderboards are made up of many of these.
-message Element {
+message _Element {
   // A player identifier, session identifier, browser identifier or whatever other kind of
   // identifier you use for this scoreboard. The full unsigned 64 bit range is allowed here,
   // between 0 and 2^63-1 inclusive.
@@ -89,7 +89,7 @@ message Element {
 
 // Query APIs returning RankedElement offer the familiar Element id and score tuple, but they
 // also include the rank per the individual API's ranking semantic.
-message RankedElement {
+message _RankedElement {
   uint64 id = 1;
   float score = 2;
   uint64 rank = 3;
@@ -112,7 +112,7 @@ message RankedElement {
 // * 0..0
 // * 4..3
 // * 0..8193
-message RankRange {
+message _RankRange {
   uint64 start_inclusive = 1;
   uint64 end_exclusive = 2;
 }
@@ -122,71 +122,71 @@ message RankRange {
 // matching many elements.
 //
 // ScoreRange models half-open ranges: 0..4 refers to scores 0, 1.1234, 2.5 and 3.999.
-message ScoreRange {
+message _ScoreRange {
   // IEEE 754 single precision 32 bit floating point number.
   // Momento does not support NaN or Inf in leaderboards.
-  float score_start = 1;
+  float start_inclusive = 1;
   // IEEE 754 single precision 32 bit floating point number.
   // Momento does not support NaN or Inf in leaderboards.
-  float score_end = 2;
+  float end_exclusive = 2;
 }
 
-message Empty {}
+message _Empty {}
 
-message DeleteLeaderboardRequest {
+message _DeleteLeaderboardRequest {
   string cache_name = 1;
   string leaderboard = 2;
 }
 
-message GetLeaderboardLengthRequest {
+message _GetLeaderboardLengthRequest {
   string cache_name = 1;
   string leaderboard = 2;
 }
 
-message GetLeaderboardLengthResponse {
+message _GetLeaderboardLengthResponse {
    uint64 count = 1;
 }
 
-message UpsertElementsRequest {
+message _UpsertElementsRequest {
   string cache_name = 1;
   string leaderboard = 2;
   // You can have up to 8192 elements in this list.
-  repeated Element elements = 3;
+  repeated _Element elements = 3;
 }
 
-message GetByRankRequest {
+message _GetByRankRequest {
   string cache_name = 1;
   string leaderboard = 2;
-  RankRange rank_range = 3;
+  _RankRange rank_range = 3;
 }
 
-message GetByRankResponse {
-  repeated RankedElement elements = 1;
+message _GetByRankResponse {
+  repeated _RankedElement elements = 1;
 }
 
-message GetRankRequest {
+message _GetRankRequest {
   string cache_name = 1;
   string leaderboard = 2;
   uint64 id = 3;
 }
 
-message RemoveElementsRequest {
+message _RemoveElementsRequest {
   string cache_name = 1;
   string leaderboard = 2;
   // You can have up to 8192 ids in this list.
   repeated uint64 ids = 3;
 }
 
-message GetByScoreRequest {
+message _GetByScoreRequest {
   string cache_name = 1;
   string leaderboard = 2;
-  ScoreRange score_range = 3;
+  _ScoreRange score_range = 3;
   // Where should we start returning scores from in the elements within this range?
   uint64 offset = 4;
   // How many elements should we limit to returning? (8192 max)
   uint64 limit_elements = 5;
 }
 
-message GetByScoreResponse {
-  repeated RankedElement elements = 1;
+message _GetByScoreResponse {
+  repeated _RankedElement elements = 1;
 }


### PR DESCRIPTION
A first step toward a leaderboard offering, I've documented and
translated the internal proposal to a grpc protocol buffers spec.

This isn't connected to any client languages yet; those can be
opted in as we add support and implement the service.
