### PR TITLE
feat: add more vector index item metadata value types

### DIFF
--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -37,12 +37,17 @@ message _Vector {
 
 message _Metadata {
     string field = 1;
+
+    message ListOfStrings {
+        repeated string values = 1;
+    }
+
     oneof value {
         string string_value = 2;
-	int64 integer_value = 3;
-	double double_value = 4;
-	bool boolean_value = 5;
-	repeated string list_of_strings_value = 6;
+        int64 integer_value = 3;
+        double double_value = 4;
+        bool boolean_value = 5;
+        ListOfStrings list_of_strings_value = 6;
     }
 }
 

--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -38,7 +38,7 @@ message _Vector {
 message _Metadata {
     string field = 1;
 
-    message ListOfStrings {
+    message _ListOfStrings {
         repeated string values = 1;
     }
 
@@ -47,7 +47,7 @@ message _Metadata {
         int64 integer_value = 3;
         double double_value = 4;
         bool boolean_value = 5;
-        ListOfStrings list_of_strings_value = 6;
+        _ListOfStrings list_of_strings_value = 6;
     }
 }
 

--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -38,8 +38,11 @@ message _Vector {
 message _Metadata {
     string field = 1;
     oneof value {
-        // Eventually can support ints, dates, etc
         string string_value = 2;
+	int64 integer_value = 3;
+	double double_value = 4;
+	bool boolean_value = 5;
+	repeated string list_of_strings_value = 6;
     }
 }
 


### PR DESCRIPTION
Expands vector index item metadata value types to allow not just
string but:
- integer (int64)
- double (64-bit precision float)
- boolean
- list of strings

These values cover commonly used metadata types.
