### PR TITLE
chore: factor out NoScoreThreshold in vectorindex proto

### DIFF
--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -64,8 +64,9 @@ message _MetadataRequest {
     }
 }
 
+message _NoScoreThreshold {}
+
 message _SearchRequest {
-    message _NoScoreThreshold {}
     string index_name = 1;
     uint32 top_k = 2;
     _Vector query_vector = 3;
@@ -77,7 +78,6 @@ message _SearchRequest {
 }
 
 message _SearchAndFetchVectorsRequest {
-    message _NoScoreThreshold {}
     string index_name = 1;
     uint32 top_k = 2;
     _Vector query_vector = 3;


### PR DESCRIPTION
Factor out NoScoreThreshold message - it is defined twice in vectorindex proto