### PR TITLE
feat: add detail to MVI list indexes RPC

### DIFF
--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -21,19 +21,27 @@ service ScsControl {
   rpc ListIndexes(_ListIndexesRequest) returns (_ListIndexesResponse) {}
 }
 
+message _SimilarityMetric {
+  message _EuclideanSimilarity {
+  }
+
+  message _InnerProduct {
+  }
+
+  message _CosineSimilarity {
+  }
+
+  oneof similarity_metric {
+    _EuclideanSimilarity euclidean_similarity = 1;
+    _InnerProduct inner_product = 2;
+    _CosineSimilarity cosine_similarity = 3;
+  }
+}
+
 message _CreateIndexRequest {
-  message _EuclideanSimilarity{}
-
-  message _InnerProduct{}
-
-  message _CosineSimilarity{}
   string index_name = 1;
   uint64 num_dimensions = 2;
-  oneof similarity_metric {
-    _EuclideanSimilarity euclidean_similarity = 3;
-    _InnerProduct inner_product = 4;
-    _CosineSimilarity cosine_similarity = 5;
-  }
+  _SimilarityMetric similarity_metric = 3;
 }
 
 message _CreateIndexResponse {
@@ -50,7 +58,12 @@ message _ListIndexesRequest {
 }
 
 message _ListIndexesResponse {
-  repeated string index_names = 1;
+  message _Index {
+    string index_name = 1;
+    uint64 num_dimensions = 2;
+    _SimilarityMetric similarity_metric = 3;
+  }
+  repeated _Index indexes = 1;
 }
 
 message _DeleteCacheRequest {


### PR DESCRIPTION
Previously the list indexes RPC only returned a list of index
names. This PR modifies this to return a list of index detail
containing index name, num dimensions, and similarity metric.

We also factor out the similarity metric message from the
`CreateIndexRequest` since it is common to create index, list indexes,
and (in the future) describe index.

Because the service is in early beta we have carefully weighed
changing this and have agreed the earlier the better.
