### PR TITLE
chore: mvi - change distance field to score to align with similarity

### DIFF
--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -91,13 +91,13 @@ message _SearchAndFetchVectorsRequest {
 
 message _SearchHit {
     string id = 1;
-    float distance = 2;
+    float score = 2;
     repeated _Metadata metadata = 3;
 }
 
 message _SearchAndFetchVectorsHit {
     string id = 1;
-    float distance = 2;
+    float score = 2;
     repeated _Metadata metadata = 3;
     _Vector vector = 4;
 }


### PR DESCRIPTION
The SearchHit and SearchAndFetchVectorHit structures currently include
a distance field, which is misleading and inconsistent with our naming
conventions. To clarify:

(1) Our Search RPCs utilize a score_threshold to filter results,
implying the evaluation of scores rather than distances.

(2) The term distance suggests that a lower value is preferable,
whereas our system employs similarity metrics where a higher value
signifies better similarity. For example, cosine similarity is a
common metric we use, where a higher score indicates greater
similarity.

To avoid confusion and maintain consistency, we are renaming the
distance field to score. This change is a simple renaming and does not
alter the representation on the wire, ensuring that existing
integrations remain functional.
