### PR TITLE
feat: add ListIndex detail

### DIFF
--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -21,19 +21,27 @@ service ScsControl {
   rpc ListIndexes(_ListIndexesRequest) returns (_ListIndexesResponse) {}
 }
 
+message _SimilarityMetric {
+  message _EuclideanSimilarity {
+  }
+
+  message _InnerProduct {
+  }
+
+  message _CosineSimilarity {
+  }
+
+  oneof similarity_metric {
+    _EuclideanSimilarity euclidean_similarity = 1;
+    _InnerProduct inner_product = 2;
+    _CosineSimilarity cosine_similarity = 3;
+  }
+}
+
 message _CreateIndexRequest {
-  message _EuclideanSimilarity{}
-
-  message _InnerProduct{}
-
-  message _CosineSimilarity{}
   string index_name = 1;
   uint64 num_dimensions = 2;
-  oneof similarity_metric {
-    _EuclideanSimilarity euclidean_similarity = 3;
-    _InnerProduct inner_product = 4;
-    _CosineSimilarity cosine_similarity = 5;
-  }
+  _SimilarityMetric similarity_metric = 3;
 }
 
 message _CreateIndexResponse {
@@ -50,7 +58,12 @@ message _ListIndexesRequest {
 }
 
 message _ListIndexesResponse {
-  repeated string index_names = 1;
+  message _Index {
+    string index_name = 1;
+    uint64 num_dimensions = 2;
+    _SimilarityMetric similarity_metric = 3;
+  }
+  repeated _Index indexes = 1;
 }
 
 message _DeleteCacheRequest {

--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -91,13 +91,13 @@ message _SearchAndFetchVectorsRequest {
 
 message _SearchHit {
     string id = 1;
-    float distance = 2;
+    float score = 2;
     repeated _Metadata metadata = 3;
 }
 
 message _SearchAndFetchVectorsHit {
     string id = 1;
-    float distance = 2;
+    float score = 2;
     repeated _Metadata metadata = 3;
     _Vector vector = 4;
 }


### PR DESCRIPTION
Currently, when we called `listIndex`, it only returns the name of indexes. We have not provided a way for customer to know about other index details. Therefore, we want to include `number of dimensions` and `similarity metric type` when calling listIndex