### PR TITLE
feat: search filter expression - equals, and, or, not

### DIFF
--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -66,6 +66,39 @@ message _MetadataRequest {
     }
 }
 
+message _AndExpression {
+    _FilterExpression first_expression = 1;
+    _FilterExpression second_expression = 2;
+}
+
+message _OrExpression {
+    _FilterExpression first_expression = 1;
+    _FilterExpression second_expression = 2;
+}
+
+message _NotExpression {
+    _FilterExpression not_expression = 1;
+}
+
+message _EqualsExpression {
+    string field = 1;
+    oneof value {
+        string string_val = 2;
+        int64 int_val = 3;
+        float float_val = 4;
+        bool bool_val = 5;
+    }
+}
+
+message _FilterExpression {
+    oneof expression {
+        _EqualsExpression equals_expr = 1;
+        _AndExpression and_expr = 2;
+        _OrExpression or_expr = 3;
+        _NotExpression not_expr = 4;
+    }
+}
+
 message _NoScoreThreshold {}
 
 message _SearchRequest {
@@ -77,6 +110,7 @@ message _SearchRequest {
         float score_threshold = 5;
         _NoScoreThreshold no_score_threshold = 6;
     }
+    _FilterExpression filter_expression = 7;
 }
 
 message _SearchAndFetchVectorsRequest {
@@ -88,6 +122,7 @@ message _SearchAndFetchVectorsRequest {
         float score_threshold = 5;
         _NoScoreThreshold no_score_threshold = 6;
     }
+    _FilterExpression filter_expression = 7;
 }
 
 message _SearchHit {
@@ -112,25 +147,25 @@ message _SearchAndFetchVectorsResponse {
 }
 
 message _GetItemBatchRequest {
-  string index_name = 1;
-  repeated string ids = 2;
-  _MetadataRequest metadata_fields = 3;
+    string index_name = 1;
+    repeated string ids = 2;
+    _MetadataRequest metadata_fields = 3;
 }
 
 message _ItemResponse {
-  message _Miss {}
-  message _Hit {
-    string id = 1;
-    repeated _Metadata metadata = 2;
-  }
-  oneof response {
-    _Miss miss = 1;
-    _Hit hit = 2;
-  }
+    message _Miss {}
+    message _Hit {
+        string id = 1;
+        repeated _Metadata metadata = 2;
+    }
+    oneof response {
+        _Miss miss = 1;
+        _Hit hit = 2;
+    }
 }
 
 message _GetItemBatchResponse {
-  repeated _ItemResponse item_response = 1;
+    repeated _ItemResponse item_response = 1;
 }
 
 message _GetItemAndFetchVectorsBatchRequest {


### PR DESCRIPTION
This feature will filter the search results based on the expression user provided. We only support `EQUALS`, `AND`, `OR`, `NOT` for now.