### PR TITLE
feat: search filter expression

### DIFF
--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -83,42 +83,42 @@ message _NotExpression {
 message _EqualsExpression {
     string field = 1;
     oneof value {
-        string string_val = 2;
-        int64 int_val = 3;
-        float float_val = 4;
-        bool bool_val = 5;
+        string string_value = 2;
+        int64 integer_value = 3;
+        float float_value = 4;
+        bool boolean_value = 5;
     }
 }
 
 message _GreaterThanExpression {
     string field = 1;
     oneof value {
-        int64 int_val = 2;
-        float float_val = 3;
+        int64 integer_value = 2;
+        float float_value = 3;
     }
 }
 
 message _GreaterOrEqualExpression {
     string field = 1;
     oneof value {
-        int64 int_val = 2;
-        float float_val = 3;
+        int64 integer_value = 2;
+        float float_value = 3;
     }
 }
 
 message _LessThanExpression {
     string field = 1;
     oneof value {
-        int64 int_val = 2;
-        float float_val = 3;
+        int64 integer_value = 2;
+        float float_value = 3;
     }
 }
 
 message _LessOrEqualExpression {
     string field = 1;
     oneof value {
-        int64 int_val = 2;
-        float float_val = 3;
+        int64 integer_value = 2;
+        float float_value = 3;
     }
 }
 
@@ -129,15 +129,15 @@ message _ListContainsExpression {
 
 message _FilterExpression {
     oneof expression {
-        _EqualsExpression equals_expr = 1;
-        _AndExpression and_expr = 2;
-        _OrExpression or_expr = 3;
-        _NotExpression not_expr = 4;
-        _GreaterThanExpression greater_than_expr = 5;
-        _GreaterOrEqualExpression greater_or_equal_expr = 6;
-        _LessThanExpression less_than_expr = 7;
-        _LessOrEqualExpression less_or_equal_expr = 8;
-        _ListContainsExpression list_contains_expr = 9;
+        _EqualsExpression equals_expression = 1;
+        _AndExpression and_expression = 2;
+        _OrExpression or_expression = 3;
+        _NotExpression not_expression = 4;
+        _GreaterThanExpression greater_than_expression = 5;
+        _GreaterOrEqualExpression greater_or_equal_expression = 6;
+        _LessThanExpression less_than_expression = 7;
+        _LessOrEqualExpression less_or_equal_expression = 8;
+        _ListContainsExpression list_contains_expression = 9;
     }
 }
 

--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -66,6 +66,81 @@ message _MetadataRequest {
     }
 }
 
+message _AndExpression {
+    _FilterExpression first_expression = 1;
+    _FilterExpression second_expression = 2;
+}
+
+message _OrExpression {
+    _FilterExpression first_expression = 1;
+    _FilterExpression second_expression = 2;
+}
+
+message _NotExpression {
+    _FilterExpression not_expression = 1;
+}
+
+message _EqualsExpression {
+    string field = 1;
+    oneof value {
+        string string_val = 2;
+        int64 int_val = 3;
+        float float_val = 4;
+        bool bool_val = 5;
+    }
+}
+
+message _GreaterThanExpression {
+    string field = 1;
+    oneof value {
+        int64 int_val = 2;
+        float float_val = 3;
+    }
+}
+
+message _GreaterOrEqualExpression {
+    string field = 1;
+    oneof value {
+        int64 int_val = 2;
+        float float_val = 3;
+    }
+}
+
+message _LessThanExpression {
+    string field = 1;
+    oneof value {
+        int64 int_val = 2;
+        float float_val = 3;
+    }
+}
+
+message _LessOrEqualExpression {
+    string field = 1;
+    oneof value {
+        int64 int_val = 2;
+        float float_val = 3;
+    }
+}
+
+message _ListContainsExpression {
+    string field = 1;
+    string value = 2;
+}
+
+message _FilterExpression {
+    oneof expression {
+        _EqualsExpression equals_expr = 1;
+        _AndExpression and_expr = 2;
+        _OrExpression or_expr = 3;
+        _NotExpression not_expr = 4;
+        _GreaterThanExpression greater_than_expr = 5;
+        _GreaterOrEqualExpression greater_or_equal_expr = 6;
+        _LessThanExpression less_than_expr = 7;
+        _LessOrEqualExpression less_or_equal_expr = 8;
+        _ListContainsExpression list_contains_expr = 9;
+    }
+}
+
 message _NoScoreThreshold {}
 
 message _SearchRequest {
@@ -77,6 +152,7 @@ message _SearchRequest {
         float score_threshold = 5;
         _NoScoreThreshold no_score_threshold = 6;
     }
+    _FilterExpression filter_expression = 7;
 }
 
 message _SearchAndFetchVectorsRequest {
@@ -88,6 +164,7 @@ message _SearchAndFetchVectorsRequest {
         float score_threshold = 5;
         _NoScoreThreshold no_score_threshold = 6;
     }
+    _FilterExpression filter_expression = 7;
 }
 
 message _SearchHit {
@@ -112,25 +189,25 @@ message _SearchAndFetchVectorsResponse {
 }
 
 message _GetItemBatchRequest {
-  string index_name = 1;
-  repeated string ids = 2;
-  _MetadataRequest metadata_fields = 3;
+    string index_name = 1;
+    repeated string ids = 2;
+    _MetadataRequest metadata_fields = 3;
 }
 
 message _ItemResponse {
-  message _Miss {}
-  message _Hit {
-    string id = 1;
-    repeated _Metadata metadata = 2;
-  }
-  oneof response {
-    _Miss miss = 1;
-    _Hit hit = 2;
-  }
+    message _Miss {}
+    message _Hit {
+        string id = 1;
+        repeated _Metadata metadata = 2;
+    }
+    oneof response {
+        _Miss miss = 1;
+        _Hit hit = 2;
+    }
 }
 
 message _GetItemBatchResponse {
-  repeated _ItemResponse item_response = 1;
+    repeated _ItemResponse item_response = 1;
 }
 
 message _GetItemAndFetchVectorsBatchRequest {

--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -77,7 +77,7 @@ message _OrExpression {
 }
 
 message _NotExpression {
-    _FilterExpression not_expression = 1;
+    _FilterExpression expression_to_negate = 1;
 }
 
 message _EqualsExpression {

--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -194,7 +194,6 @@ message _GetItemMetadataBatchRequest {
     _MetadataRequest metadata_fields = 3;
 }
 
-
 message _ItemMetadataResponse {
     message _Miss {}
     message _Hit {


### PR DESCRIPTION
This feature will filter the search results based on the expression user provided. We support `EQUALS`, `AND`, `OR`, `NOT`, `>`, `>=`, `<`, `<=` and `LIST_CONTAINS` for now.