### PR TITLE
feat: add optional description field when generating API Keys

### DIFF
--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -76,6 +76,8 @@ message _GenerateApiTokenRequest {
     permission_messages.Permissions permissions = 4;
 
     string token_id = 5;
+
+    string description = 6;
 }
 
 message _GenerateApiTokenResponse {


### PR DESCRIPTION
This one is pretty straightforward - adds a single optional string field to the API for generating API Keys, which will eventually be displayed when managing API Keys, allowing users to use this field for notes/names/etc to distinguish keys.