### PR TITLE
chore: automatically release kotlin protos

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -178,7 +178,7 @@ jobs:
         with:
           build-root-directory: ./kotlin
           gradle-version: wrapper
-          arguments: publishToSonatype closeSonatypeStagingRepository
+          arguments: publishToSonatype closeAndReleaseStagingRepository
 
   publish_python:
     # The type of runner that the job will run on


### PR DESCRIPTION
Automatically complete the sonatype release process. I've verified that the produced artifact is releasable and have manually approved a release.