### PR TITLE
chore: moving f32 score field to reserved

### DIFF
--- a/proto/leaderboard.proto
+++ b/proto/leaderboard.proto
@@ -61,18 +61,19 @@ message _Element {
   uint32 id = 1;
 
   // The value by which this element is sorted within the leaderboard.
-  float score_f32 = 2 [deprecated = true];
-
   double score = 3;
+
+  reserved 2;
 }
 
 // Query APIs returning RankedElement offer the familiar Element id and score tuple, but they
 // also include the rank per the individual API's ranking semantic.
 message _RankedElement {
   uint32 id = 1;
-  float score_f32 = 2 [deprecated = true];
   uint32 rank = 3;
   double score = 4;
+
+  reserved 2;
 }
 
 // Query APIs using RankRange expect a limit of 8192 elements. Requesting a range wider than
@@ -107,18 +108,18 @@ message _Unbounded { }
 message _ScoreRange {
   oneof min {
     _Unbounded unbounded_min = 1;
-    // IEEE 754 single precision 32 bit floating point number.
+    // IEEE 754 single precision 64 bit floating point number.
     // Momento does not support NaN or Inf in leaderboards.
-    float min_inclusive_f32 = 2 [deprecated = true];
     double min_inclusive = 5;
   }
   oneof max {
     _Unbounded unbounded_max = 3;
-    // IEEE 754 single precision 32 bit floating point number.
+    // IEEE 754 single precision 64 bit floating point number.
     // Momento does not support NaN or Inf in leaderboards.
-    float max_exclusive_f32 = 4 [deprecated = true];
     double max_exclusive = 6;
   }
+
+  reserved 2, 4;
 }
 
 enum _Order {


### PR DESCRIPTION
We have completely migrated to using the f64 score field in SDKs and canaries. We can now safely more the f32 score field to reserved.