### PR TITLE
chore: rename filter expression field

### DIFF
--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -160,7 +160,7 @@ message _SearchRequest {
         float score_threshold = 5;
         _NoScoreThreshold no_score_threshold = 6;
     }
-    _FilterExpression filter_expression = 7;
+    _FilterExpression filter = 7;
 }
 
 message _SearchAndFetchVectorsRequest {
@@ -172,7 +172,7 @@ message _SearchAndFetchVectorsRequest {
         float score_threshold = 5;
         _NoScoreThreshold no_score_threshold = 6;
     }
-    _FilterExpression filter_expression = 7;
+    _FilterExpression filter = 7;
 }
 
 message _SearchHit {


### PR DESCRIPTION
On the SDKs we will opt for a shorter name, consistent across `search`,
`searchAndFetchVectors`, `get item`, `get item metadata`, and
`delete`. Further, on the SDKs for latter three, we will accept a list
of ids (strings) as a convenience, so the name filter expression does
not apply.
