### PR TITLE
feat: support filters for mvi get items and delete items

### DIFF
--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -30,6 +30,7 @@ message _UpsertItemBatchResponse {
 message _DeleteItemBatchRequest {
     string index_name = 1;
     repeated string ids = 2;
+    _FilterExpression filter = 3;
 }
 
 message _DeleteItemBatchResponse {
@@ -200,6 +201,7 @@ message _GetItemMetadataBatchRequest {
     string index_name = 1;
     repeated string ids = 2;
     _MetadataRequest metadata_fields = 3;
+    _FilterExpression filter = 4;
 }
 
 message _ItemMetadataResponse {
@@ -222,6 +224,7 @@ message _GetItemBatchRequest {
     string index_name = 1;
     repeated string ids = 2;
     _MetadataRequest metadata_fields = 3;
+    _FilterExpression filter = 4;
 }
 
 message _ItemResponse {

--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -29,7 +29,7 @@ message _UpsertItemBatchResponse {
 
 message _DeleteItemBatchRequest {
     string index_name = 1;
-    repeated string ids = 2;
+    repeated string ids = 2; // TODO: reserve after migration
     _FilterExpression filter = 3;
 }
 
@@ -199,7 +199,7 @@ message _SearchAndFetchVectorsResponse {
 
 message _GetItemMetadataBatchRequest {
     string index_name = 1;
-    repeated string ids = 2;
+    repeated string ids = 2; // TODO: reserve after migration
     _MetadataRequest metadata_fields = 3;
     _FilterExpression filter = 4;
 }
@@ -211,9 +211,11 @@ message _ItemMetadataResponse {
         repeated _Metadata metadata = 2;
     }
     oneof response {
-        _Miss miss = 1;
-        _Hit hit = 2;
+        _Miss miss = 1; // TODO: reserve after migration
+        _Hit hit = 2; // TODO: reserve after migration
     }
+    string id = 3;
+    repeated _Metadata metadata = 4;
 }
 
 message _GetItemMetadataBatchResponse {
@@ -235,9 +237,12 @@ message _ItemResponse {
         repeated _Metadata metadata = 3;
     }
     oneof response {
-        _Miss miss = 1;
-        _Hit hit = 2;
+        _Miss miss = 1; // TODO: reserve after migration
+        _Hit hit = 2; // TODO: reserve after migration
     }
+    string id = 3;
+    _Vector vector = 4;
+    repeated _Metadata metadata = 5;
 }
 
 message _GetItemBatchResponse {


### PR DESCRIPTION
This PR adds a filter field for the `get item batch`, `get item
metadata batch`, and `delete item batch` RPCs. Currently we allow
users to select items by id. Now that we have an `_IdInSetExpression`
filter expression, users may use that select purely by ID. Otherwise
they may use a more general filter expression.

Until we migrate users to newer clients, we will support both methods
of selecting items: by a list of ids (previous version) and by filter
expression (new version). Once they have migrated we will change the
ids field to reserved.
