### PR TITLE
chore: bump gRPC versions

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "1.9.0",
+        "@grpc/grpc-js": "1.10.0",
         "google-protobuf": "3.21.2",
         "grpc-tools": "^1.12.4",
         "protoc-gen-ts": "^0.8.6"
@@ -22,11 +22,11 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
-      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.0.tgz",
+      "integrity": "sha512-tx+eoEsqkMkLCHR4OOplwNIaJ7SVZWzeVKzEMBz8VR+TbssgBYOP4a0P+KQiQ6LaTG4SGaIEu7YTS8xOmkOWLA==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
       },
       "engines": {
@@ -876,11 +876,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
-      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.0.tgz",
+      "integrity": "sha512-tx+eoEsqkMkLCHR4OOplwNIaJ7SVZWzeVKzEMBz8VR+TbssgBYOP4a0P+KQiQ6LaTG4SGaIEu7YTS8xOmkOWLA==",
       "requires": {
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
       }
     },

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -21,7 +21,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@grpc/grpc-js": "1.9.0",
+    "@grpc/grpc-js": "1.10.0",
     "google-protobuf": "3.21.2",
     "grpc-tools": "^1.12.4",
     "protoc-gen-ts": "^0.8.6"


### PR DESCRIPTION
gRPC 1.9.14 release had a couple fixes relevant to issues we were seeing with reconnections:

- https://github.com/grpc/grpc-node/issues/2620
- https://github.com/grpc/grpc-node/pull/2643
- https://github.com/grpc/grpc-node/pull/2644