### PR TITLE
feat: mvi depcreate old delete/get item request/response fields

### DIFF
--- a/proto/vectorindex.proto
+++ b/proto/vectorindex.proto
@@ -29,7 +29,7 @@ message _UpsertItemBatchResponse {
 
 message _DeleteItemBatchRequest {
     string index_name = 1;
-    repeated string ids = 2; // TODO: reserve after migration
+    reserved 2; // deprecated ids field
     _FilterExpression filter = 3;
 }
 
@@ -199,21 +199,14 @@ message _SearchAndFetchVectorsResponse {
 
 message _GetItemMetadataBatchRequest {
     string index_name = 1;
-    repeated string ids = 2; // TODO: reserve after migration
+    reserved 2; // deprecated ids field
     _MetadataRequest metadata_fields = 3;
     _FilterExpression filter = 4;
 }
 
 message _ItemMetadataResponse {
-    message _Miss {}
-    message _Hit {
-        string id = 1;
-        repeated _Metadata metadata = 2;
-    }
-    oneof response {
-        _Miss miss = 1; // TODO: reserve after migration
-        _Hit hit = 2; // TODO: reserve after migration
-    }
+    reserved 1; // deprecated miss field
+    reserved 2; // deprecated hit field
     string id = 3;
     repeated _Metadata metadata = 4;
 }
@@ -224,22 +217,14 @@ message _GetItemMetadataBatchResponse {
 
 message _GetItemBatchRequest {
     string index_name = 1;
-    repeated string ids = 2;
+    reserved 2; // deprecated ids field
     _MetadataRequest metadata_fields = 3;
     _FilterExpression filter = 4;
 }
 
 message _ItemResponse {
-    message _Miss {}
-    message _Hit {
-        string id = 1;
-        _Vector vector = 2;
-        repeated _Metadata metadata = 3;
-    }
-    oneof response {
-        _Miss miss = 1; // TODO: reserve after migration
-        _Hit hit = 2; // TODO: reserve after migration
-    }
+    reserved 1; // deprecated miss field
+    reserved 2; // deprecated hit field
     string id = 3;
     _Vector vector = 4;
     repeated _Metadata metadata = 5;


### PR DESCRIPTION
This PR deprecates two features of the previous request/response model
for `delete item batch`, `get item metadata batch`, and `get item
batch` RPCs:

(1) ids in the request: these RPCs now accept a general filter, which
can contain a set of ids. Because that behavior subsumes the old way,
we deprecate it.

(2) hit and miss pattern in get item response: because we no longer
always request items by id, we cannot use the hit and miss pattern
in the response. Instead we return a list of matching items.

Because the clients have already been updated to use the new
request/response model, this is not a breaking change.
