### PR TITLE
chore: move common messages to common.proto

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -721,15 +721,13 @@ message _ListRemoveResponse {
   list_size_one_[0:-1] == []
  */
 
-message _Unbounded { }
-
 message _ListFetchRequest {
   bytes list_name = 1;
   // Inclusive.
   // If unbounded, 0 (start of list) by default
   // A negative index counts from the end of the list
   oneof start_index {
-    _Unbounded unbounded_start = 2;
+    common._Unbounded unbounded_start = 2;
     sint32 inclusive_start = 3;
   }
   // Exclusive.
@@ -737,7 +735,7 @@ message _ListFetchRequest {
   // If end_index is > the number of elements to return, return as much as you can
   // A negative index counts from the end of the list
   oneof end_index {
-    _Unbounded unbounded_end = 4;
+    common._Unbounded unbounded_end = 4;
     sint32 exclusive_end = 5;
   }
 }
@@ -745,11 +743,11 @@ message _ListFetchRequest {
 message _ListRetainRequest {
   bytes list_name = 1;
   oneof start_index {
-    _Unbounded unbounded_start = 2;
+    common._Unbounded unbounded_start = 2;
     sint32 inclusive_start = 3;
   }
   oneof end_index {
-    _Unbounded unbounded_end = 4;
+    common._Unbounded unbounded_end = 4;
     sint32 exclusive_end = 5;
   }
   uint64 ttl_milliseconds = 6;
@@ -827,13 +825,13 @@ message _SortedSetFetchRequest {
     // Start is inclusive.
     // Unbounded is treated as 0.
     oneof start {
-      _Unbounded unbounded_start = 1;
+      common._Unbounded unbounded_start = 1;
       sint32 inclusive_start_index = 2;
     }
     // End is exclusive.
     // Unbounded is treated as the number of elements in the sorted set.
     oneof end {
-      _Unbounded unbounded_end = 3;
+      common._Unbounded unbounded_end = 3;
       sint32 exclusive_end_index = 4;
     }
   }
@@ -845,11 +843,11 @@ message _SortedSetFetchRequest {
     }
 
     oneof min {
-      _Unbounded unbounded_min = 1;
+      common._Unbounded unbounded_min = 1;
       _Score min_score = 2;
     }
     oneof max {
-      _Unbounded unbounded_max = 3;
+      common._Unbounded unbounded_max = 3;
       _Score max_score = 4;
     }
     // Offset and count are used to only get a range of the matching elements,
@@ -1002,12 +1000,12 @@ message _SortedSetLengthByScoreRequest {
   oneof min {
     double inclusive_min = 2;
     double exclusive_min = 3;
-    _Unbounded unbounded_min = 4;
+    common._Unbounded unbounded_min = 4;
   };
   oneof max {
     double inclusive_max = 5;
     double exclusive_max = 6;
-    _Unbounded unbounded_max = 7;
+    common._Unbounded unbounded_max = 7;
   }
 }
 

--- a/proto/cachepubsub.proto
+++ b/proto/cachepubsub.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "common.proto";
 import "extensions.proto";
 
 option go_package = "github.com/momentohq/client-sdk-go;client_sdk_go";
@@ -35,7 +36,7 @@ service Pubsub {
   // practice it should almost always deliver to subscribers.
   //
   // REQUIRES HEADER authorization: Momento auth token
-  rpc Publish(_PublishRequest) returns (_Empty);
+  rpc Publish(_PublishRequest) returns (common._Empty);
 
   // Subscribe to notifications from a topic.
   //
@@ -45,8 +46,6 @@ service Pubsub {
   // REQUIRES HEADER authorization: Momento auth token
   rpc Subscribe(_SubscriptionRequest) returns (stream _SubscriptionItem);
 }
-
-message _Empty {}
 
 // A value to publish through a topic.
 message _PublishRequest {

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -26,3 +26,7 @@ message AbsentOrEqual {
 message NotEqual {
   bytes value_to_check = 1;
 }
+
+message _Unbounded { }
+
+message _Empty {}

--- a/proto/leaderboard.proto
+++ b/proto/leaderboard.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "common.proto";
+
 option go_package = "github.com/momentohq/client-sdk-go;client_sdk_go";
 option java_multiple_files = true;
 option java_package = "grpc.leaderboard";
@@ -21,16 +23,16 @@ package leaderboard;
 // below -16777216 and above 16777216, not all integers are able to be represented.
 service Leaderboard {
   // Deletes a leaderboard. After this call, you're not incurring storage cost for this leaderboard anymore.
-  rpc DeleteLeaderboard(_DeleteLeaderboardRequest) returns (_Empty);
+  rpc DeleteLeaderboard(_DeleteLeaderboardRequest) returns (common._Empty);
 
   // Insert or update elements in a leaderboard. You can do up to 8192 elements per call.
   // There is no partial failure: Upsert succeeds or fails.
-  rpc UpsertElements(_UpsertElementsRequest) returns (_Empty);
+  rpc UpsertElements(_UpsertElementsRequest) returns (common._Empty);
 
   // Remove up to 8192 elements at a time from a leaderboard. Elements are removed by id.
-  rpc RemoveElements(_RemoveElementsRequest) returns (_Empty);
+  rpc RemoveElements(_RemoveElementsRequest) returns (common._Empty);
 
-  // Returns the length of a leaderboard in terms of ID count. 
+  // Returns the length of a leaderboard in terms of ID count.
   rpc GetLeaderboardLength(_GetLeaderboardLengthRequest) returns (_GetLeaderboardLengthResponse);
 
   // Get a range of elements.
@@ -98,8 +100,6 @@ message _RankRange {
   uint32 end_exclusive = 2;
 }
 
-message _Unbounded { }
-
 // Query APIs using ScoreRange may match more than the limit of 8192 elements. These apis will
 // include an offset and limit parameter pair, which can be used to page through score ranges
 // matching many elements.
@@ -107,13 +107,13 @@ message _Unbounded { }
 // ScoreRange models half-open ranges: 0..4 refers to scores 0, 1.1234, 2.5 and 3.999.
 message _ScoreRange {
   oneof min {
-    _Unbounded unbounded_min = 1;
+    common._Unbounded unbounded_min = 1;
     // IEEE 754 single precision 64 bit floating point number.
     // Momento does not support NaN or Inf in leaderboards.
     double min_inclusive = 5;
   }
   oneof max {
-    _Unbounded unbounded_max = 3;
+    common._Unbounded unbounded_max = 3;
     // IEEE 754 single precision 64 bit floating point number.
     // Momento does not support NaN or Inf in leaderboards.
     double max_exclusive = 6;
@@ -128,8 +128,6 @@ enum _Order {
   // Descending order (0 is the highest-scoring rank)
   DESCENDING = 1;
 }
-
-message _Empty {}
 
 message _DeleteLeaderboardRequest {
   string cache_name = 1;


### PR DESCRIPTION
This commit refactors the `Unbounded` and `Empty` messages out to `common.proto`. This was motivated by build failures in the golang SDK, where the multiply declared messages were flagged as having been redefined because all messages live in the same package namespace.