### PR TITLE
chore: add prefix to store service messages

### DIFF
--- a/proto/global_admin.proto
+++ b/proto/global_admin.proto
@@ -1,5 +1,10 @@
 syntax = "proto3";
 
+option go_package = "github.com/momentohq/client-sdk-go;client_sdk_go";
+option java_multiple_files = true;
+option java_package = "grpc.global_admin";
+option csharp_namespace = "Momento.Protos.GlobalAdmin";
+
 package global_admin;
 
 service GlobalAdmin {

--- a/proto/store.proto
+++ b/proto/store.proto
@@ -8,12 +8,12 @@ option csharp_namespace = "Momento.Protos.Store";
 package store;
 
 service Store {
-  rpc Get(_GetRequest) returns (_GetResponse) {}
-  rpc Set(_SetRequest) returns (_SetResponse) {}
-  rpc Delete(_DeleteRequest) returns (_DeleteResponse) {}
+  rpc Get(_StoreGetRequest) returns (_StoreGetResponse) {}
+  rpc Set(_StoreSetRequest) returns (_StoreSetResponse) {}
+  rpc Delete(_StoreDeleteRequest) returns (_StoreDeleteResponse) {}
 }
 
-message _Value {
+message _StoreValue {
   oneof value {
     bytes bytes_value = 1;
     string string_value = 2;
@@ -22,23 +22,23 @@ message _Value {
   }
 }
 
-message _GetRequest {
+message _StoreGetRequest {
   string key = 1;
 }
 
-message _GetResponse {
-  _Value value = 1;
+message _StoreGetResponse {
+  _StoreValue value = 1;
 }
 
-message _SetRequest {
+message _StoreSetRequest {
   string key = 1;
-  _Value value = 2;
+  _StoreValue value = 2;
 }
 
-message _SetResponse { }
+message _StoreSetResponse { }
 
-message _DeleteRequest {
+message _StoreDeleteRequest {
   string key = 1;
 }
 
-message _DeleteResponse { }
+message _StoreDeleteResponse { }


### PR DESCRIPTION
This commit prefixes the names of the messages in `store.proto` with the string "Store" to resolve name collisions in the Go SDK. In that SDK all of the messages end up living in the same namespace, so all of the request and response messages (e.g. `_GetRequest`) were colliding with the names in `cacheclient.proto`.

@honeyAcorn @anp13 I wanted to make sure you were both aware of and in agreement with this change. Please let me know if you see any issues or problems with renaming these.