### PR TITLE
fix: s/membership_status/role

### DIFF
--- a/proto/global_admin.proto
+++ b/proto/global_admin.proto
@@ -79,14 +79,14 @@ message _RemoveMemberResponse {
 message _ListMembersRequest {
 }
 
-enum MembershipStatus {
+enum Role {
   OWNER = 0;
   MEMBER = 1;
 }
 
 message _Member {
   string user_name = 1;
-  MembershipStatus membership_status = 2;
+  Role role = 2;
 }
 
 message _ListMembersResponse {


### PR DESCRIPTION
## PR Description:
Use "role" instead of "membership_status" to match the mr2rs protos: https://github.com/momentohq/mr2rs/blob/main/proto/global_admin.proto