### PR TITLE
feat: add leaderboard api proto for rust

### DIFF
--- a/rust/momento-protos/src/lib.rs
+++ b/rust/momento-protos/src/lib.rs
@@ -29,3 +29,7 @@ pub mod control_client {
 pub mod store {
   include!("store.rs");
 }
+
+pub mod leaderboard {
+  include!("leaderboard.rs");
+}

--- a/rust/proto_generator/build.rs
+++ b/rust/proto_generator/build.rs
@@ -27,6 +27,7 @@ fn main() {
                 format!("{proto_dir}/cachepubsub.proto"),
                 format!("{proto_dir}/controlclient.proto"),
                 format!("{proto_dir}/store.proto"),
+                format!("{proto_dir}/leaderboard.proto"),
             ],
             &[proto_dir],
         )


### PR DESCRIPTION
Adds the leaderboard api proto to the rust crate.