### PR TITLE
chore: adding permissionrules.proto into js-web proto file list

### DIFF
--- a/javascript-web/generate_protos.sh
+++ b/javascript-web/generate_protos.sh
@@ -4,7 +4,7 @@ set -x
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   platform='darwin-x86_64'
-  sed_command="sed -i ''"
+  sed_command="sed -i \'\'"
 elif [[ "$OSTYPE" == "linux"* ]]; then
   platform='linux-x86_64'
   sed_command="sed -i"
@@ -72,17 +72,18 @@ function generate_proto() {
   echo "Commenting out package declarations"
   for f in $proto_file_list
   do
-    $sed_command 's/^\s*package \(.*\)/\/\/package \1/g' ../proto/${f}
-    $sed_command 's/permission_messages.Permissions/Permissions/g' ../proto/${f}
-    $sed_command 's/permission_rules.PermissionSet/PermissionSet/g' ../proto/${f}
-    $sed_command 's/common._Unbounded/_Unbounded/g' ../proto/${f}
-    $sed_command 's/common._Empty/_Empty/g' ../proto/${f}
-    $sed_command 's/common.Present/Present/g' ../proto/${f}
-    $sed_command 's/common.PresentAndNotEqual/PresentAndNotEqual/g' ../proto/${f}
-    $sed_command 's/common.Absent/Absent/g' ../proto/${f}
-    $sed_command 's/common.Equal/Equal/g' ../proto/${f}
-    $sed_command 's/common.AbsentOrEqual/AbsentOrEqual/g' ../proto/${f}
-    $sed_command 's/common.NotEqual/NotEqual/g' ../proto/${f}
+    $sed_command 's/^\s*package \(.*\)/\/\/package \1/g' ../proto/"${f}"
+    $sed_command 's/permission_messages.Permissions/Permissions/g' ../proto/"${f}"
+    $sed_command 's/permission_rules.PermissionSet/PermissionSet/g' ../proto/"${f}"
+    $sed_command 's/common._Unbounded/_Unbounded/g' ../proto/"${f}"
+    $sed_command 's/common._Empty/_Empty/g' ../proto/"${f}"
+    $sed_command 's/common.Present/Present/g' ../proto/"${f}"
+    $sed_command 's/common.PresentAndNotEqual/PresentAndNotEqual/g' ../proto/"${f}"
+    $sed_command 's/common.Absent/Absent/g' ../proto/"${f}"
+    $sed_command 's/common.Equal/Equal/g' ../proto/"${f}"
+    $sed_command 's/common.AbsentOrEqual/AbsentOrEqual/g' ../proto/"${f}"
+    $sed_command 's/common.NotEqual/NotEqual/g' ../proto/"${f}"
+    $sed_command 's/common.SuperUserPermissions/SuperUserPermissions/g' ../proto/"${f}"
   done
 
   protoc -I=../proto -I=/usr/local/include \

--- a/javascript-web/generate_protos.sh
+++ b/javascript-web/generate_protos.sh
@@ -74,6 +74,7 @@ function generate_proto() {
   do
     $sed_command 's/^\s*package \(.*\)/\/\/package \1/g' ../proto/${f}
     $sed_command 's/permission_messages.Permissions/Permissions/g' ../proto/${f}
+    $sed_command 's/permission_rules.PermissionSet/PermissionSet/g' ../proto/${f}
     $sed_command 's/common._Unbounded/_Unbounded/g' ../proto/${f}
     $sed_command 's/common._Empty/_Empty/g' ../proto/${f}
     $sed_command 's/common.Present/Present/g' ../proto/${f}
@@ -97,5 +98,5 @@ function generate_proto() {
     ${proto_file_list}
 }
 
-proto_file_list=" common.proto permissionmessages.proto extensions.proto cacheclient.proto controlclient.proto auth.proto cacheping.proto cachepubsub.proto token.proto webhook.proto leaderboard.proto global_admin.proto store.proto "
+proto_file_list=" common.proto permissionrules.proto permissionmessages.proto extensions.proto cacheclient.proto controlclient.proto auth.proto cacheping.proto cachepubsub.proto token.proto webhook.proto leaderboard.proto global_admin.proto store.proto "
 generate_proto "${proto_file_list[@]}"

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -30,3 +30,7 @@ message NotEqual {
 message _Unbounded { }
 
 message _Empty {}
+
+enum SuperUserPermissions {
+  SuperUser = 0;
+}

--- a/proto/permissionmessages.proto
+++ b/proto/permissionmessages.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "common.proto";
+
 option go_package = "github.com/momentohq/client-sdk-go;client_sdk_go";
 option java_multiple_files = true;
 option java_package = "grpc.permission_messages";
@@ -30,13 +32,9 @@ enum TopicRole {
   TopicWriteOnly = 3;
 }
 
-enum SuperUserPermissions {
-  SuperUser = 0;
-}
-
 message Permissions {
   oneof kind {
-    SuperUserPermissions super_user = 1;
+    common.SuperUserPermissions super_user = 1;
     ExplicitPermissions explicit = 2;
   }
 }

--- a/proto/permissionrules.proto
+++ b/proto/permissionrules.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "common.proto";
+
 option go_package = "github.com/momentohq/client-sdk-go;client_sdk_go";
 option java_multiple_files = true;
 option java_package = "grpc.permission_rules";
@@ -117,16 +119,12 @@ message TopicSelector {
 
 message PermissionSet {
   oneof kind {
-    SuperUserPermissions super_user = 1;
-    ExplicitPermissions explicit = 2;
+    common.SuperUserPermissions super_user = 1;
+    ExplicitPermissionSet explicit = 2;
   }
 }
 
-enum SuperUserPermissions {
-  SuperUser = 0;
-}
-
-message ExplicitPermissions {
+message ExplicitPermissionSet {
   repeated Rule rules = 1;
 }
 


### PR DESCRIPTION
This commit includes the previously omitted `permissionsrules.proto` into the javascript-web protos file list. It also follows the pattern established with `permissionmessages.proto`, removing the namespace prefix before compilation.