### PR TITLE
feat: add SortedSetUnionStore api

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -94,6 +94,9 @@ service Scs {
   rpc SortedSetLength(_SortedSetLengthRequest) returns (_SortedSetLengthResponse) {}
   // Returns number of elements in the sorted set between a given min and max score
   rpc SortedSetLengthByScore(_SortedSetLengthByScoreRequest) returns (_SortedSetLengthByScoreResponse) {}
+  // Computes the union of multiple sorted sets using weights and an aggregate function and stores the result in itself
+  // If the sorted set exists, its value is overwritten.
+  rpc SortedSetUnionStore(_SortedSetUnionStoreRequest) returns (_SortedSetUnionStoreResponse) {}
 }
 
 message _GetRequest {
@@ -1023,5 +1026,37 @@ message _SortedSetLengthByScoreResponse {
   oneof sorted_set {
     _Found found = 1;
     _Missing missing = 2;
+  }
+}
+
+message _SortedSetUnionStoreRequest {
+  enum AggregateFunction {
+    SUM = 0;
+    MIN = 1;
+    MAX = 2;
+  }
+
+  message _Source {
+    bytes set_name = 1;
+    optional float weight = 2;
+  }
+
+  bytes set_name = 1;
+  repeated _Source sources = 2;
+  AggregateFunction aggregate = 3;
+  uint64 ttl_milliseconds = 4;
+  bool refresh_ttl = 5;
+}
+
+message _SortedSetUnionStoreResponse {
+  message _Stored {
+    uint32 length = 1;
+  }
+
+  message _NotStored {}
+
+  oneof sorted_set {
+    _Stored stored = 1;
+    _NotStored not_stored = 2;
   }
 }

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -1054,7 +1054,7 @@ message _SortedSetUnionStoreRequest {
   // The destination set where the result of the union is stored.
   bytes set_name = 1;
 
-  // The sets to compute the union for. Note the desination set is not implicitly included as a source.
+  // The sets to compute the union for. Note that the destination set is not implicitly included as a source.
   // It must be explicitly specified in sources if its current contents need to be included in the union.
   repeated _Source sources = 2;
 

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -94,8 +94,13 @@ service Scs {
   rpc SortedSetLength(_SortedSetLengthRequest) returns (_SortedSetLengthResponse) {}
   // Returns number of elements in the sorted set between a given min and max score
   rpc SortedSetLengthByScore(_SortedSetLengthByScoreRequest) returns (_SortedSetLengthByScoreResponse) {}
-  // Computes the union of multiple sorted sets using weights and an aggregate function and stores the result in itself
-  // If the sorted set exists, its value is overwritten.
+  // Computes the union of all the source sets and stores the result in itself. If the set does not
+  // exist, it is created with the given `ttl`. If it exists, it is overwritten with the result and 
+  // its ttl is set to the given `ttl`. If the set exists but the result of the union is empty, it is deleted.
+  // The union is computed by applying the corresponding weight multiplier to the score of all elements
+  // in each source set, and then using the aggregate function to combine the weighted scores for elements
+  // existing in multiple source sets.
+  // Returns the number of elements in the set after storing the result of the union.
   rpc SortedSetUnionStore(_SortedSetUnionStoreRequest) returns (_SortedSetUnionStoreResponse) {}
 }
 
@@ -1029,24 +1034,39 @@ message _SortedSetLengthByScoreResponse {
   }
 }
 
+
 message _SortedSetUnionStoreRequest {
   enum AggregateFunction {
+    // Sum the weighted scores of an element across all the source sets. This is the default.
     SUM = 0;
+    // Use the minimum of the weight scores of an element across all the source sets.
     MIN = 1;
+    // Use the maximum of the weight scores of an element across all the source sets.
     MAX = 2;
   }
 
   message _Source {
     bytes set_name = 1;
+    // A multiplier applied to the score of each element in the set before aggregation. Negative and zero weights are allowed.
     float weight = 2;
   }
 
+  // The destination set where the result of the union is stored.
   bytes set_name = 1;
+
+  // The sets to compute the union for. Note the desination set is not implicitly included as a source.
+  // It must be explicitly specified in sources if its current contents need to be included in the union.
   repeated _Source sources = 2;
+
+  // Aggregate function to determine the final score for an element that exists in multiple source sets
   AggregateFunction aggregate = 3;
+
+  // The TTL for the destination set if the result is non-empty
   uint64 ttl_milliseconds = 4;
 }
 
 message _SortedSetUnionStoreResponse {
+  // The number of elements in the destination set after the union.
+  // The length is 0 if the result of the union was an empty set.
   uint32 length = 1;
 }

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -1038,25 +1038,15 @@ message _SortedSetUnionStoreRequest {
 
   message _Source {
     bytes set_name = 1;
-    optional float weight = 2;
+    float weight = 2;
   }
 
   bytes set_name = 1;
   repeated _Source sources = 2;
   AggregateFunction aggregate = 3;
   uint64 ttl_milliseconds = 4;
-  bool refresh_ttl = 5;
 }
 
 message _SortedSetUnionStoreResponse {
-  message _Stored {
-    uint32 length = 1;
-  }
-
-  message _NotStored {}
-
-  oneof sorted_set {
-    _Stored stored = 1;
-    _NotStored not_stored = 2;
-  }
+  uint32 length = 1;
 }


### PR DESCRIPTION
This PR adds a New API `SortedSetUnionStore` that does the equivalent of Redis's `ZUNIONSTORE`
The union of elements in the source sorted sets is computed using the given weights and aggregate function, and the result is stored in the target set on which the api is invoked.