### PR TITLE
chore: bump grpc-js to v1.13.1 in javascript

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "1.10.9",
+        "@grpc/grpc-js": "1.13.1",
         "google-protobuf": "3.21.2",
         "grpc-tools": "^1.12.4",
         "protoc-gen-ts": "^0.8.6"
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.10.9",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.9.tgz",
-      "integrity": "sha512-5tcgUctCG0qoNyfChZifz2tJqbRbXVO9J7X6duFcOjY3HUNCxg5D0ZCK7EP9vIcZ0zRpLU9bWkyCqVCLZ46IbQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.1.tgz",
+      "integrity": "sha512-z5nNuIs75S73ZULjPDe5QCNTiCv7FyBZXEVWOyAHtcebnuJf0g1SuueI3U1/z/KK39XyAQRUC+C9ZQJOtgHynA==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -21,7 +21,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@grpc/grpc-js": "1.10.9",
+    "@grpc/grpc-js": "1.13.1",
     "google-protobuf": "3.21.2",
     "grpc-tools": "^1.12.4",
     "protoc-gen-ts": "^0.8.6"


### PR DESCRIPTION
Bumps the `@grpc/grpc-js` dependency to the latest version (v1.13.1)
in the javascript project.
