### PR TITLE
chore: javascript(-web) should specify protobuf as a peer dependency

### DIFF
--- a/javascript-web/package-lock.json
+++ b/javascript-web/package-lock.json
@@ -8,17 +8,16 @@
       "name": "@gomomento/generated-types-webtext",
       "version": "0.0.1",
       "license": "Apache-2.0",
-      "dependencies": {
-        "google-protobuf": "3.21.2"
-      },
       "devDependencies": {
         "@tsconfig/node16": "1.0.2",
         "@types/google-protobuf": "^3.15.6",
         "@types/node": "16.10.3",
+        "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2",
         "typescript": "^4.9.5"
       },
       "peerDependencies": {
+        "google-protobuf": "3.21.2",
         "grpc-web": "1.4.2"
       }
     },
@@ -43,7 +42,8 @@
     "node_modules/google-protobuf": {
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
+      "dev": true
     },
     "node_modules/grpc-web": {
       "version": "1.4.2",
@@ -87,7 +87,8 @@
     "google-protobuf": {
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
+      "dev": true
     },
     "grpc-web": {
       "version": "1.4.2",

--- a/javascript-web/package.json
+++ b/javascript-web/package.json
@@ -19,13 +19,13 @@
     "@tsconfig/node16": "1.0.2",
     "@types/google-protobuf": "^3.15.6",
     "@types/node": "16.10.3",
+    "google-protobuf": "3.21.2",
     "grpc-web": "1.4.2",
     "typescript": "^4.9.5"
   },
-  "dependencies": {
-    "google-protobuf": "3.21.2"
-  },
+  "dependencies": {},
   "peerDependencies": {
+    "google-protobuf": "3.21.2",
     "grpc-web": "1.4.2"
   },
   "files": [

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -8,20 +8,19 @@
       "name": "@gomomento/generated-types",
       "version": "0.0.1",
       "license": "Apache-2.0",
-      "dependencies": {
-        "google-protobuf": "3.21.2"
-      },
       "devDependencies": {
         "@grpc/grpc-js": "1.13.1",
         "@tsconfig/node16": "1.0.2",
         "@types/google-protobuf": "3.15.6",
         "@types/node": "16.10.3",
+        "google-protobuf": "3.21.2",
         "grpc-tools": "^1.12.4",
         "protoc-gen-ts": "^0.8.6",
         "typescript": "4.9.5"
       },
       "peerDependencies": {
-        "@grpc/grpc-js": "1.13.1"
+        "@grpc/grpc-js": "1.13.1",
+        "google-protobuf": "3.21.2"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -435,7 +434,8 @@
     "node_modules/google-protobuf": {
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
+      "dev": true
     },
     "node_modules/grpc-tools": {
       "version": "1.12.4",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -19,15 +19,15 @@
     "@tsconfig/node16": "1.0.2",
     "@types/google-protobuf": "3.15.6",
     "@types/node": "16.10.3",
+    "google-protobuf": "3.21.2",
     "grpc-tools": "^1.12.4",
     "protoc-gen-ts": "^0.8.6",
     "typescript": "4.9.5"
   },
-  "dependencies": {
-    "google-protobuf": "3.21.2"
-  },
+  "dependencies": {},
   "peerDependencies": {
-    "@grpc/grpc-js": "1.13.1"
+    "@grpc/grpc-js": "1.13.1",
+    "google-protobuf": "3.21.2"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Similar to #315, protobuf should be a peer dependency in the
JavaScript projects. Since the SDKs install protobuf alongside grpc,
they are vulnerable to the same deduplication problem as we had with
grpc.
