### PR TITLE
feat: add protosocket-rpc cache protocols

### DIFF
--- a/proto/protosocket/cache.proto
+++ b/proto/protosocket/cache.proto
@@ -1,0 +1,84 @@
+syntax = "proto3";
+
+import "protosocket/common.proto";
+
+// This is the protobuf definition for the Momento Cache service.
+// It is available over protosocket-rpc.
+package cache;
+
+// All messages sent to the server by a client must be CacheCommands.
+message CacheCommand {
+  // This is the unique identifier used for the command. The server will return this id in the response.
+  // As protosocket-rpc does not necessarily respond in-order this is used to correlate responses with requests.
+  uint64 message_id = 2;
+  // The protosocket-rpc control code.
+  uint32 control_code = 3;
+  // The protosocket-rpc rpc kind.
+  oneof rpc_kind {
+    Unary unary = 10;
+  }
+}
+
+// These are Unary (single request -> single response) commands.
+message Unary {
+  oneof command {
+    // Authenticate provides the auth token to be used for all future requests on the connection.
+    // - It MUST be the first command sent on every cache connection.
+    // - It MAY be resent later in the connection to provide a different auth token.
+    //   - If sent mid-connection, clients SHOULD wait to pipeline further commands until the corresponding response is received.
+    //     If clients do not wait, it is indeterminate whether the prior or new auth token will be used for those requests.
+    AuthenticateCommand auth = 1;
+    // Retrieves an item from cache.
+    GetCommand get = 2;
+    // Set an item in cache.
+    SetCommand set = 3;
+    // Deletes an item from cache.
+    DeleteCommand delete = 4;
+  }
+}
+
+// All messages sent by the server to a client will be CacheResponses.
+message CacheResponse {
+  // This is the message id provided in the corresponding command.
+  uint64 message_id = 1;
+  // The protosocket-rpc control code.
+  uint32 control_code = 2;
+  // The specific response.
+  oneof kind {
+    common.CommandError error = 9;
+    AuthenticateResponse auth = 10;
+    GetResponse get = 11;
+    SetResponse set = 12;
+    DeleteResponse delete = 13;
+  }
+}
+
+message AuthenticateCommand {
+  string token = 1;
+}
+
+message AuthenticateResponse {}
+
+message GetCommand {
+  string namespace = 1;
+  bytes key = 2;
+}
+
+message GetResponse {
+  bytes value = 1;
+}
+
+message SetCommand {
+  string namespace = 1;
+  bytes key = 2;
+  bytes value = 3;
+  uint64 ttl_milliseconds = 4;
+}
+message SetResponse {}
+
+message DeleteCommand {
+  string namespace = 1;
+  bytes key = 2;
+}
+message DeleteResponse {
+}

--- a/proto/protosocket/common.proto
+++ b/proto/protosocket/common.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+// This package is for protos we anticipate being used across customer-facing protosocket+protobuf services.
+package common;
+
+enum Status {
+  OK = 0;
+  CANCELLED = 1;
+  UNKNOWN = 2;
+  INVALID_ARGUMENT = 3;
+  DEADLINE_EXCEEDED = 4;
+  NOT_FOUND = 5;
+  ALREADY_EXISTS = 6;
+  PERMISSION_DENIED = 7;
+  RESOURCE_EXHAUSTED = 8;
+  FAILED_PRECONDITION = 9;
+  ABORTED = 10;
+  OUT_OF_RANGE = 11;
+  UNIMPLEMENTED = 12;
+  INTERNAL = 13;
+  UNAVAILABLE = 14;
+  DATA_LOSS = 15;
+  UNAUTHENTICATED = 16;
+}
+
+message CommandError {
+  Status code = 1;
+  string message = 2;
+}

--- a/rust/momento-protos/Cargo.toml
+++ b/rust/momento-protos/Cargo.toml
@@ -6,12 +6,13 @@ repository = "https://github.com/momentohq/client_protos"
 license = "Apache-2.0"
 version = "0.1.0"
 authors = ["<eng@momentohq.com>"]
-edition = "2021"
+edition = "2024"
 keywords = ["service", "performance", "cache"]
 categories = ["web-programming"]
 includes = [
     "Cargo.toml",
     "src/**/*.rs",
+    "src/**/**/*.rs",
     "../proto",
 ]
 

--- a/rust/momento-protos/src/.gitignore
+++ b/rust/momento-protos/src/.gitignore
@@ -3,3 +3,4 @@
 
 # Need this file to list the proto module imports
 !lib.rs
+!protosocket/mod.rs

--- a/rust/momento-protos/src/lib.rs
+++ b/rust/momento-protos/src/lib.rs
@@ -1,3 +1,13 @@
+pub mod protosocket {
+    pub mod common {
+        include!("protosocket/common.rs");
+    }
+
+    pub mod cache {
+        include!("protosocket/cache.rs");
+    }
+}
+
 pub mod permission_messages {
   include!("permission_messages.rs");
 }

--- a/rust/momento-protos/src/protosocket/.gitignore
+++ b/rust/momento-protos/src/protosocket/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory - this is purely generated.
+*
+# Except this file
+!.gitignore

--- a/rust/proto_generator/build.rs
+++ b/rust/proto_generator/build.rs
@@ -17,7 +17,7 @@ fn main() {
     tonic_build::configure()
         .build_client(true)
         .build_server(true)
-        .out_dir(out_dir)
+        .out_dir(out_dir.clone())
         .compile_protos(
             &[
                 format!("{proto_dir}/permissionmessages.proto"),
@@ -33,6 +33,19 @@ fn main() {
             &[proto_dir],
         )
         .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));
+
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .out_dir(out_dir.join("protosocket"))
+        .compile_protos(
+            &[
+            format!("{proto_dir}/protosocket/common.proto"),
+            format!("{proto_dir}/protosocket/cache.proto"),
+                ],
+            &[proto_dir],
+        )
+        .unwrap_or_else(|e| panic!("Failed to compile protosocket protos {:?}", e));
 
     println!("cargo:rerun-if-changed=../proto");
 }


### PR DESCRIPTION
for reference: [example implementation in rust sdk](https://github.com/momentohq/client-sdk-rust/pull/473)